### PR TITLE
Refactor organization edit page into components

### DIFF
--- a/resources/js/components/keywords/KeywordListItem.vue
+++ b/resources/js/components/keywords/KeywordListItem.vue
@@ -1,0 +1,38 @@
+<script setup>
+const props = defineProps({
+  keyword: { type: Object, required: true },
+  isSelected: { type: Boolean, default: false }
+})
+const emit = defineEmits(['select', 'delete'])
+</script>
+
+<template>
+  <div
+    class="p-4 border border-neutral-200 rounded-lg hover:border-neutral-300 transition-colors cursor-pointer"
+    :class="{ 'border-2 border-neutral-400 bg-neutral-50': isSelected }"
+    @click="$emit('select', keyword)"
+  >
+    <div class="flex justify-between items-center">
+      <div>
+        <span class="text-lg font-medium text-neutral-800">{{ keyword.name }}</span>
+        <div v-if="keyword.prompts_count >= 0" class="text-sm text-neutral-500 mt-1">
+          Found in {{ keyword.prompts_count }}
+          {{ keyword.prompts_count === 1 ? 'prompt' : 'prompts' }}
+        </div>
+        <div v-else class="text-sm text-neutral-500 mt-1">New keyword</div>
+      </div>
+      <button
+        @click.stop="$emit('delete', keyword)"
+        class="text-neutral-400 hover:text-neutral-600 transition-colors cursor-pointer"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path
+            fill-rule="evenodd"
+            d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/keywords/KeywordNotification.vue
+++ b/resources/js/components/keywords/KeywordNotification.vue
@@ -1,0 +1,21 @@
+<script setup>
+const props = defineProps({
+  message: { type: String, default: null }
+})
+</script>
+
+<template>
+  <div
+    v-if="message"
+    class="p-4 mb-3 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+      <path
+        fill-rule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    {{ message }}
+  </div>
+</template>

--- a/resources/js/components/keywords/RecommendedKeywordItem.vue
+++ b/resources/js/components/keywords/RecommendedKeywordItem.vue
@@ -1,0 +1,47 @@
+<script setup>
+const props = defineProps({
+  keyword: { type: Object, required: true }
+})
+const emit = defineEmits(['accept', 'deny'])
+</script>
+
+<template>
+  <div class="p-4 border border-neutral-200 rounded-lg">
+    <div class="flex justify-between items-center">
+      <div>
+        <span class="text-lg font-medium text-neutral-800">{{ keyword.name }}</span>
+        <div v-if="keyword.description" class="text-sm text-neutral-500 mt-1">
+          {{ keyword.description }}
+        </div>
+      </div>
+      <div class="flex gap-2">
+        <button
+          @click="$emit('accept', keyword)"
+          class="text-green-600 hover:text-green-800 transition-colors cursor-pointer"
+          title="Accept this keyword"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fill-rule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+        <button
+          @click="$emit('deny', keyword)"
+          class="text-red-600 hover:text-red-800 transition-colors cursor-pointer"
+          title="Deny this keyword"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fill-rule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/organizations/OrganizationForm.vue
+++ b/resources/js/components/organizations/OrganizationForm.vue
@@ -1,0 +1,43 @@
+<script setup>
+import Button from '@/components/ui/Button.vue'
+
+const props = defineProps({
+  organization: { type: Object, required: true },
+  hasChanges: { type: Boolean, default: false },
+  isSubmitting: { type: Boolean, default: false }
+})
+const emit = defineEmits(['update'])
+</script>
+
+<template>
+  <div class="w-full md:w-1/3">
+    <h2 class="text-xl font-semibold mb-2">
+      Edit {{ organization.is_competitor ? 'competitor' : 'your organization' }}
+    </h2>
+    <form @submit.prevent="$emit('update')" class="space-y-3">
+      <div>
+        <label class="block text-sm font-medium text-neutral-700 mb-1">Name</label>
+        <input
+          v-model="organization.name"
+          type="text"
+          class="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Enter organization name"
+        />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-neutral-700 mb-1">Website</label>
+        <input
+          v-model="organization.website"
+          type="text"
+          class="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Enter website URL"
+        />
+      </div>
+      <div class="pt-4">
+        <Button v-if="hasChanges" type="submit" :disabled="isSubmitting" variant="dark">
+          {{ isSubmitting ? 'Saving...' : 'Save Changes' }}
+        </Button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/resources/js/components/prompts/DeletePromptModal.vue
+++ b/resources/js/components/prompts/DeletePromptModal.vue
@@ -1,0 +1,20 @@
+<script setup>
+const props = defineProps({
+  isOpen: { type: Boolean, required: true },
+  prompt: { type: Object, default: null }
+})
+const emit = defineEmits(['confirm', 'cancel'])
+</script>
+
+<template>
+  <div v-if="isOpen" class="fixed inset-0 bg-neutral-300/50 flex items-center justify-center z-50" @click="$emit('cancel')">
+    <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4" @click.stop>
+      <h3 class="text-lg font-medium text-neutral-900 mb-4">Delete Prompt</h3>
+      <p class="text-sm text-neutral-600 mb-6">Are you sure you want to delete this prompt? This action cannot be undone.</p>
+      <div class="flex justify-end space-x-3">
+        <button @click="$emit('cancel')" class="ml-3 inline-flex justify-center px-4 py-2 bg-neutral-200 hover:bg-neutral-100 text-neutral-800 rounded-md cursor-pointer">Cancel</button>
+        <button @click="$emit('confirm')" class="ml-3 inline-flex justify-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md cursor-pointer">Delete</button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/prompts/PromptListItem.vue
+++ b/resources/js/components/prompts/PromptListItem.vue
@@ -1,0 +1,88 @@
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  prompt: { type: Object, required: true },
+  isSelected: { type: Boolean, default: false },
+  loadingPromptIds: { type: Array, default: () => [] },
+  jobs: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['select', 'run', 'delete'])
+const isRunMenuOpen = ref(false)
+
+const isLoading = computed(() => props.loadingPromptIds.includes(props.prompt.id))
+const hasActiveJob = computed(() => props.jobs.some(job => job.trackable_id === props.prompt.id && (job.status === 'pending' || job.status === 'processing')))
+
+const toggleRunMenu = () => {
+  isRunMenuOpen.value = !isRunMenuOpen.value
+}
+const closeRunMenu = () => {
+  isRunMenuOpen.value = false
+}
+const runPrompt = (count) => {
+  emit('run', props.prompt.id, count)
+  closeRunMenu()
+}
+const confirmDelete = () => emit('delete', props.prompt)
+</script>
+
+<template>
+  <div
+    class="flex items-start justify-between p-4 border border-neutral-300 hover:border-neutral-400 hover:bg-neutral-50 rounded-lg cursor-pointer"
+    :class="{ 'border-2 border-neutral-400 bg-neutral-50': isSelected }"
+    @click="$emit('select', prompt)"
+  >
+    <div>
+      <p class="text-neutral-800 text-lg">{{ prompt.content }}</p>
+      <div v-if="prompt.keywords_count >= 0" class="flex items-center gap-2 text-sm text-neutral-500 mt-1">
+        <p v-if="prompt.mentions_percentage !== undefined">
+          Mentioned {{ prompt.mentions_percentage }}% of the time out of
+          {{ prompt.responses_count }}
+          {{ prompt.responses_count === 1 ? 'response' : 'responses' }}
+        </p>
+        <p>•</p>
+        <p>
+          {{ prompt.keywords_count }} keyword
+          {{ prompt.keywords_count === 1 ? 'occurrence' : 'occurrences' }}
+        </p>
+      </div>
+      <div v-else class="text-sm text-neutral-500 mt-1">New prompt</div>
+
+      <div v-if="hasActiveJob" class="mt-2 flex items-center text-sm text-blue-600">
+        <div class="animate-spin h-3 w-3 border-b-2 border-blue-600 rounded-full mr-2"></div>
+        <span>Processing...</span>
+      </div>
+    </div>
+    <div class="flex justify-end space-x-2">
+      <div class="relative flex items-center">
+        <button
+          @click.stop="toggleRunMenu"
+          class="px-3 py-1 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer flex items-center justify-center min-w-[40px]"
+          :disabled="isLoading"
+        >
+          <div v-if="isLoading" class="animate-spin h-3 w-3 border-b-2 border-neutral-800 rounded-full"></div>
+          <span v-else>Run</span>
+        </button>
+        <div
+          v-if="isRunMenuOpen"
+          class="absolute right-0 mt-1 w-20 bg-white border border-neutral-300 rounded-md shadow-lg z-10 overflow-hidden"
+          @click.stop
+        >
+          <button @click.stop="runPrompt(1)" class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run 1x</button>
+          <button @click.stop="runPrompt(3)" class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run 3x</button>
+          <button @click.stop="runPrompt(5)" class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run 5x</button>
+        </div>
+      </div>
+      <button
+        @click.stop="confirmDelete"
+        class="-mr-2 p-1.5 text-neutral-400 hover:text-neutral-600 transition-colors cursor-pointer"
+        aria-label="Delete prompt"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/prompts/PromptToolbar.vue
+++ b/resources/js/components/prompts/PromptToolbar.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  sortOption: { type: String, default: 'default' },
+  isLoading: { type: Boolean, default: false },
+  isRunningAll: { type: Boolean, default: false },
+  disableRunAll: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['update:sortOption', 'run-all', 'add', 'generate'])
+
+const isRunAllMenuOpen = ref(false)
+
+const toggleRunAllMenu = () => {
+  isRunAllMenuOpen.value = !isRunAllMenuOpen.value
+}
+const closeRunAllMenu = () => {
+  isRunAllMenuOpen.value = false
+}
+const runAll = (count) => {
+  emit('run-all', count)
+  closeRunAllMenu()
+}
+</script>
+
+<template>
+  <div class="flex justify-between items-center">
+    <div class="flex items-center gap-3">
+      <h1 class="text-2xl font-bold">Prompts</h1>
+      <div v-if="isLoading" class="animate-spin rounded-full size-4 border-b-2 border-neutral-800"></div>
+    </div>
+
+    <div class="flex space-x-2">
+      <div class="relative inline-block">
+        <select
+          :value="sortOption"
+          @change="$emit('update:sortOption', $event.target.value)"
+          class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium appearance-none pr-8 cursor-pointer"
+        >
+          <option value="default">Default order</option>
+          <option value="mentions-desc">Mentions (high to low)</option>
+          <option value="mentions-asc">Mentions (low to high)</option>
+        </select>
+        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-neutral-700">
+          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </div>
+      </div>
+
+      <div class="relative">
+        <button
+          @click.stop="toggleRunAllMenu"
+          class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer flex items-center justify-center"
+          :disabled="disableRunAll"
+        >
+          <div v-if="isRunningAll" class="animate-spin h-3 w-3 border-b-2 border-neutral-800 rounded-full mr-1"></div>
+          <span>Run all prompts</span>
+        </button>
+        <div
+          v-if="isRunAllMenuOpen"
+          class="absolute right-0 mt-1 w-36 bg-white border border-neutral-300 rounded-md shadow-lg z-10 overflow-hidden"
+          @click.stop
+        >
+          <button @click.stop="runAll(1)" class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run all prompts 1x</button>
+          <button @click.stop="runAll(3)" class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run all prompts 3x</button>
+          <button @click.stop="runAll(5)" class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer">Run all prompts 5x</button>
+        </div>
+      </div>
+
+      <button
+        @click="$emit('add')"
+        class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer"
+      >
+        Add a prompt
+      </button>
+
+      <button
+        @click="$emit('generate')"
+        class="flex items-center space-x-1 px-3 py-1.5 bg-neutral-800 text-white rounded-md text-xs font-medium hover:bg-neutral-700 transition-colors cursor-pointer"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+        </svg>
+        <span>Generate prompts</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/pages/organizations/Edit.vue
+++ b/resources/js/pages/organizations/Edit.vue
@@ -8,6 +8,10 @@ import Button from '@/components/ui/Button.vue'
 import KeywordDetailSheet from '@/components/keywords/KeywordDetailSheet.vue'
 import KeywordCreateModal from '@/components/keywords/KeywordCreateModal.vue'
 import GenerateKeywordsModal from '@/components/GenerateKeywordsModal.vue'
+import KeywordNotification from '@/components/keywords/KeywordNotification.vue'
+import KeywordListItem from '@/components/keywords/KeywordListItem.vue'
+import RecommendedKeywordItem from '@/components/keywords/RecommendedKeywordItem.vue'
+import OrganizationForm from '@/components/organizations/OrganizationForm.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -208,135 +212,46 @@ const denyRecommendedKeyword = async (keywordId, keywordName) => {
 							<div class="text-neutral-400 text-sm">No keywords yet</div>
 						</div>
 
-						<!-- Existing keywords list -->
-						<div v-else class="space-y-3 mb-8">
-							<div
-								v-if="deletedKeywordMessage"
-								class="p-4 mb-3 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2"
-							>
-								<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-									<path
-										fill-rule="evenodd"
-										d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-										clip-rule="evenodd"
-									/>
-								</svg>
-								{{ deletedKeywordMessage }}
-							</div>
+                                                <!-- Existing keywords list -->
+                                                <div v-else class="space-y-3 mb-8">
+                                                        <KeywordNotification :message="deletedKeywordMessage" />
 
-							<div
-								v-for="keyword in keywordStore.keywords"
-								:key="keyword.id"
-								class="p-4 border border-neutral-200 rounded-lg hover:border-neutral-300 transition-colors cursor-pointer"
-								:class="{ 'border-2 border-neutral-400 bg-neutral-50': selectedKeywordId === keyword.id }"
-								@click="showKeywordDetails(keyword)"
-							>
-								<div class="flex justify-between items-center">
-									<div>
-										<span class="text-lg font-medium text-neutral-800">{{ keyword.name }}</span>
-										<div v-if="keyword.prompts_count >= 0" class="text-sm text-neutral-500 mt-1">
-											Found in {{ keyword.prompts_count }}
-											{{ keyword.prompts_count === 1 ? 'prompt' : 'prompts' }}
-										</div>
-										<div v-else class="text-sm text-neutral-500 mt-1">New keyword</div>
-									</div>
-									<button
-										@click.stop="handleDeleteKeyword(keyword.id, keyword.name)"
-										class="text-neutral-400 hover:text-neutral-600 transition-colors cursor-pointer"
-									>
-										<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-											<path
-												fill-rule="evenodd"
-												d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-												clip-rule="evenodd"
-											/>
-										</svg>
-									</button>
-								</div>
-							</div>
-						</div>
+                                                        <KeywordListItem
+                                                                v-for="keyword in keywordStore.keywords"
+                                                                :key="keyword.id"
+                                                                :keyword="keyword"
+                                                                :is-selected="selectedKeywordId === keyword.id"
+                                                                @select="showKeywordDetails"
+                                                                @delete="(kw) => handleDeleteKeyword(kw.id, kw.name)"
+                                                        />
+                                                </div>
 
-						<!-- Recommended Keywords Section -->
-						<div v-if="keywordStore.recommendedKeywords.length > 0">
-							<h3 class="text-lg font-semibold mb-4">Recommended keywords</h3>
-							<div v-if="keywordStore.isLoadingRecommended" class="flex justify-center py-8">
-								<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-neutral-800"></div>
-							</div>
-							<div v-else class="space-y-3">
-								<div v-for="keyword in keywordStore.recommendedKeywords" :key="keyword.id" class="p-4 border border-neutral-200 rounded-lg">
-									<div class="flex justify-between items-center">
-										<div>
-											<span class="text-lg font-medium text-neutral-800">{{ keyword.name }}</span>
-											<div v-if="keyword.description" class="text-sm text-neutral-500 mt-1">
-												{{ keyword.description }}
-											</div>
-										</div>
-										<div class="flex gap-2">
-											<button
-												@click="acceptRecommendedKeyword(keyword.id)"
-												class="text-green-600 hover:text-green-800 transition-colors cursor-pointer"
-												title="Accept this keyword"
-											>
-												<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-													<path
-														fill-rule="evenodd"
-														d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-														clip-rule="evenodd"
-													/>
-												</svg>
-											</button>
-											<button
-												@click="denyRecommendedKeyword(keyword.id, keyword.name)"
-												class="text-red-600 hover:text-red-800 transition-colors cursor-pointer"
-												title="Deny this keyword"
-											>
-												<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-													<path
-														fill-rule="evenodd"
-														d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-														clip-rule="evenodd"
-													/>
-												</svg>
-											</button>
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
+                                                <!-- Recommended Keywords Section -->
+                                                <div v-if="keywordStore.recommendedKeywords.length > 0">
+                                                        <h3 class="text-lg font-semibold mb-4">Recommended keywords</h3>
+                                                        <div v-if="keywordStore.isLoadingRecommended" class="flex justify-center py-8">
+                                                                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-neutral-800"></div>
+                                                        </div>
+                                                        <div v-else class="space-y-3">
+                                                                <RecommendedKeywordItem
+                                                                        v-for="keyword in keywordStore.recommendedKeywords"
+                                                                        :key="keyword.id"
+                                                                        :keyword="keyword"
+                                                                        @accept="(kw) => acceptRecommendedKeyword(kw.id)"
+                                                                        @deny="(kw) => denyRecommendedKeyword(kw.id, kw.name)"
+                                                                />
+                                                        </div>
+                                                </div>
 					</div>
 				</div>
 
-				<!-- Right column - Organization details -->
-				<div class="w-full md:w-1/3">
-					<h2 class="text-xl font-semibold mb-2">Edit {{ organization.is_competitor ? 'competitor' : 'your organization' }}</h2>
-					<form @submit.prevent="updateOrganization" class="space-y-3">
-						<div>
-							<label class="block text-sm font-medium text-neutral-700 mb-1">Name</label>
-							<input
-								v-model="organization.name"
-								type="text"
-								class="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-								placeholder="Enter organization name"
-							/>
-						</div>
-
-						<div>
-							<label class="block text-sm font-medium text-neutral-700 mb-1">Website</label>
-							<input
-								v-model="organization.website"
-								type="text"
-								class="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-								placeholder="Enter website URL"
-							/>
-						</div>
-
-						<div class="pt-4">
-							<Button v-if="hasChanges" type="submit" :disabled="isSubmitting" variant="dark">
-								{{ isSubmitting ? 'Saving...' : 'Save Changes' }}
-							</Button>
-						</div>
-					</form>
-				</div>
+                                <!-- Right column - Organization details -->
+                                <OrganizationForm
+                                        :organization="organization"
+                                        :has-changes="hasChanges"
+                                        :is-submitting="isSubmitting"
+                                        @update="updateOrganization"
+                                />
 			</div>
 		</div>
 	</DefaultLayout>

--- a/resources/js/pages/prompts/Index.vue
+++ b/resources/js/pages/prompts/Index.vue
@@ -5,6 +5,9 @@ import { useJobStatusStore } from '@/stores/jobStatusStore'
 import PromptDetailSheet from '@/components/prompts/PromptDetailSheet.vue'
 import PromptCreateModal from '@/components/prompts/PromptCreateModal.vue'
 import GeneratePromptsModal from '@/components/GeneratePromptsModal.vue'
+import PromptToolbar from '@/components/prompts/PromptToolbar.vue'
+import PromptListItem from '@/components/prompts/PromptListItem.vue'
+import DeletePromptModal from '@/components/prompts/DeletePromptModal.vue'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 
 const promptStore = usePromptStore()
@@ -26,29 +29,9 @@ const hasActiveJobs = computed(() => {
 // Track completed jobs to detect when individual jobs complete
 const completedJobIds = ref(new Set())
 
-// Track run menu
-const openRunMenuId = ref(null)
-const isRunAllMenuOpen = ref(false)
-
 // Track prompt deletion
 const promptToDelete = ref(null)
 const showDeleteConfirmation = ref(false)
-
-const toggleRunMenu = (id) => {
-	if (openRunMenuId.value === id) {
-		openRunMenuId.value = null
-	} else {
-		openRunMenuId.value = id
-	}
-}
-
-const closeRunMenu = () => {
-	openRunMenuId.value = null
-}
-
-const closeRunAllMenu = () => {
-	isRunAllMenuOpen.value = false
-}
 
 const runPrompt = async (id, count = 1) => {
 	await promptStore.runPrompt(id, count)
@@ -159,189 +142,32 @@ onMounted(async () => {
 			<div class="flex flex-col">
 				<!-- Prompts column -->
 				<div class="w-full">
-					<div class="mb-4">
-						<div class="flex justify-between items-center">
-							<div class="flex items-center gap-3">
-								<h1 class="text-2xl font-bold">Prompts</h1>
-								<div v-if="promptStore.isLoading" class="animate-spin rounded-full size-4 border-b-2 border-neutral-800"></div>
-							</div>
+                                        <div class="mb-4">
+                                                <PromptToolbar
+                                                        :sort-option="sortOption"
+                                                        :is-loading="promptStore.isLoading"
+                                                        :is-running-all="promptStore.isRunningAll"
+                                                        :disable-run-all="promptStore.isLoading || promptStore.loadingPromptIds.length > 0 || promptStore.isRunningAll"
+                                                        @update:sort-option="(v) => (sortOption = v)"
+                                                        @run-all="runAllPrompts"
+                                                        @add="isPromptCreateModalOpen = true"
+                                                        @generate="isGenerateModalOpen = true"
+                                                />
+                                        </div>
 
-							<div class="flex space-x-2">
-								<!-- Sort prompts -->
-								<div class="relative inline-block">
-									<select
-										v-model="sortOption"
-										class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium appearance-none pr-8 cursor-pointer"
-									>
-										<option value="default">Default order</option>
-										<option value="mentions-desc">Mentions (high to low)</option>
-										<option value="mentions-asc">Mentions (low to high)</option>
-									</select>
-									<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-neutral-700">
-										<svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-											<path
-												fill-rule="evenodd"
-												d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-												clip-rule="evenodd"
-											/>
-										</svg>
-									</div>
-								</div>
-								<div class="relative">
-									<button
-										@click.stop="isRunAllMenuOpen = !isRunAllMenuOpen"
-										class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer flex items-center justify-center"
-										:disabled="promptStore.isLoading || promptStore.loadingPromptIds.length > 0 || promptStore.isRunningAll"
-									>
-										<div v-if="promptStore.isRunningAll" class="animate-spin h-3 w-3 border-b-2 border-neutral-800 rounded-full mr-1"></div>
-										<span>Run all prompts</span>
-									</button>
-									<div
-										v-if="isRunAllMenuOpen"
-										class="absolute right-0 mt-1 w-36 bg-white border border-neutral-300 rounded-md shadow-lg z-10 overflow-hidden"
-										@click.stop
-									>
-										<button
-											@click.stop="runAllPrompts(1), closeRunAllMenu()"
-											class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run all prompts 1x
-										</button>
-										<button
-											@click.stop="runAllPrompts(3), closeRunAllMenu()"
-											class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run all prompts 3x
-										</button>
-										<button
-											@click.stop="runAllPrompts(5), closeRunAllMenu()"
-											class="w-full px-3 py-2.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run all prompts 5x
-										</button>
-									</div>
-								</div>
-
-								<!-- Add single prompt -->
-								<button
-									@click="isPromptCreateModalOpen = true"
-									class="px-3 py-1.5 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer"
-								>
-									Add a prompt
-								</button>
-
-								<!-- Generate prompts -->
-								<button
-									@click="isGenerateModalOpen = true"
-									class="flex items-center space-x-1 px-3 py-1.5 bg-neutral-800 text-white rounded-md text-xs font-medium hover:bg-neutral-700 transition-colors cursor-pointer"
-								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										fill="none"
-										viewBox="0 0 24 24"
-										stroke-width="1.5"
-										stroke="currentColor"
-										class="size-4"
-									>
-										<path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
-									</svg>
-									<span>Generate prompts</span>
-								</button>
-							</div>
-						</div>
-					</div>
-
-					<div v-if="sortedPrompts.length" class="space-y-4">
-						<div
-							v-for="prompt in sortedPrompts"
-							:key="prompt.id"
-							class="flex items-start justify-between p-4 border border-neutral-300 hover:border-neutral-400 hover:bg-neutral-50 rounded-lg cursor-pointer"
-							:class="{ 'border-2 border-neutral-400 bg-neutral-50': selectedPromptId === prompt.id }"
-							@click="showPromptDetails(prompt)"
-						>
-							<div>
-								<p class="text-neutral-800 text-lg">{{ prompt.content }}</p>
-								<div v-if="prompt.keywords_count >= 0" class="flex items-center gap-2 text-sm text-neutral-500 mt-1">
-									<p v-if="prompt.mentions_percentage !== undefined">
-										Mentioned {{ prompt.mentions_percentage }}% of the time out of
-										{{ prompt.responses_count }}
-										{{ prompt.responses_count === 1 ? 'response' : 'responses' }}
-									</p>
-									<p>•</p>
-									<p class="">
-										{{ prompt.keywords_count }} keyword
-										{{ prompt.keywords_count === 1 ? 'occurrence' : 'occurrences' }}
-									</p>
-								</div>
-								<div v-else class="text-sm text-neutral-500 mt-1">New prompt</div>
-
-								<!-- Show job status indicator if there's an active job for this prompt -->
-								<div
-									v-if="
-										jobStatusStore.jobs?.some(
-											(job) => job.trackable_id === prompt.id && (job.status === 'pending' || job.status === 'processing')
-										)
-									"
-									class="mt-2 flex items-center text-sm text-blue-600"
-								>
-									<div class="animate-spin h-3 w-3 border-b-2 border-blue-600 rounded-full mr-2"></div>
-									<span>Processing...</span>
-								</div>
-							</div>
-							<div class="flex justify-end space-x-2">
-								<div class="relative flex items-center">
-									<button
-										@click.stop="toggleRunMenu(prompt.id)"
-										class="px-3 py-1 bg-white text-neutral-800 border border-neutral-400 rounded-md text-xs font-medium hover:bg-neutral-100 transition-colors cursor-pointer flex items-center justify-center min-w-[40px]"
-										:disabled="promptStore.loadingPromptIds.includes(prompt.id)"
-									>
-										<div
-											v-if="promptStore.loadingPromptIds.includes(prompt.id)"
-											class="animate-spin h-3 w-3 border-b-2 border-neutral-800 rounded-full"
-										></div>
-										<span v-else>Run</span>
-									</button>
-									<div
-										v-if="openRunMenuId === prompt.id"
-										class="absolute right-0 mt-1 w-20 bg-white border border-neutral-300 rounded-md shadow-lg z-10 overflow-hidden"
-										@click.stop
-									>
-										<button
-											@click.stop="runPrompt(prompt.id, 1), closeRunMenu()"
-											class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run 1x
-										</button>
-										<button
-											@click.stop="runPrompt(prompt.id, 3), closeRunMenu()"
-											class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run 3x
-										</button>
-										<button
-											@click.stop="runPrompt(prompt.id, 5), closeRunMenu()"
-											class="w-full px-3 py-1.5 text-left text-xs hover:bg-neutral-100 transition-colors cursor-pointer"
-										>
-											Run 5x
-										</button>
-									</div>
-								</div>
-								<button
-									@click.stop="confirmDeletePrompt(prompt)"
-									class="-mr-2 p-1.5 text-neutral-400 hover:text-neutral-600 transition-colors cursor-pointer"
-									aria-label="Delete prompt"
-								>
-									<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-										<path
-											fill-rule="evenodd"
-											d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-											clip-rule="evenodd"
-										/>
-									</svg>
-								</button>
-							</div>
-						</div>
-					</div>
+                                        <div v-if="sortedPrompts.length" class="space-y-4">
+                                                <PromptListItem
+                                                        v-for="prompt in sortedPrompts"
+                                                        :key="prompt.id"
+                                                        :prompt="prompt"
+                                                        :is-selected="selectedPromptId === prompt.id"
+                                                        :loading-prompt-ids="promptStore.loadingPromptIds"
+                                                        :jobs="jobStatusStore.jobs || []"
+                                                        @select="showPromptDetails"
+                                                        @run="(id, count) => runPrompt(id, count)"
+                                                        @delete="confirmDeletePrompt"
+                                                />
+                                        </div>
 					<div v-else class="text-center py-4 text-neutral-500 text-sm">No prompts data available</div>
 				</div>
 			</div>
@@ -367,25 +193,10 @@ onMounted(async () => {
 		"
 	/>
 
-	<!-- Delete Confirmation Modal -->
-	<div v-if="showDeleteConfirmation" class="fixed inset-0 bg-neutral-300/50 flex items-center justify-center z-50" @click="cancelDelete">
-		<div class="bg-white rounded-lg p-6 max-w-md w-full mx-4" @click.stop>
-			<h3 class="text-lg font-medium text-neutral-900 mb-4">Delete Prompt</h3>
-			<p class="text-sm text-neutral-600 mb-6">Are you sure you want to delete this prompt? This action cannot be undone.</p>
-			<div class="flex justify-end space-x-3">
-				<button
-					@click="cancelDelete"
-					class="ml-3 inline-flex justify-center px-4 py-2 bg-neutral-200 hover:bg-neutral-100 text-neutral-800 rounded-md cursor-pointer"
-				>
-					Cancel
-				</button>
-				<button
-					@click="deletePrompt"
-					class="ml-3 inline-flex justify-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md cursor-pointer"
-				>
-					Delete
-				</button>
-			</div>
-		</div>
-	</div>
+        <!-- Delete Confirmation Modal -->
+        <DeletePromptModal
+                :is-open="showDeleteConfirmation"
+                @cancel="cancelDelete"
+                @confirm="deletePrompt"
+        />
 </template>


### PR DESCRIPTION
## Summary
- split `organizations/Edit.vue` into smaller components
- add `KeywordNotification` to show keyword success messages
- add `KeywordListItem` for each keyword row
- add `RecommendedKeywordItem` to manage recommended keywords
- add `OrganizationForm` for editing organization details

## Testing
- `npm run build` *(fails: vite not found)*