### PR TITLE
Add tests for Prompt controllers

### DIFF
--- a/tests/Feature/Prompt/PromptControllerTest.php
+++ b/tests/Feature/Prompt/PromptControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\Prompt;
+use App\Models\Team;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('lists prompts for the current team', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompts = Prompt::factory()->count(2)->for($team)->create();
+    Prompt::factory()->create(); // other team
+
+    $response = $this->getJson('/api/prompts');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(2)
+        ->assertJsonPath('0.id', $prompts[0]->id)
+        ->assertJsonPath('1.id', $prompts[1]->id);
+});
+
+it('shows a prompt belonging to the team', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $this->getJson("/api/prompts/{$prompt->id}")
+        ->assertStatus(200)
+        ->assertJson(['id' => $prompt->id, 'content' => $prompt->content]);
+});
+
+it('returns 404 when showing a prompt from another team', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->create();
+
+    $this->getJson("/api/prompts/{$prompt->id}")->assertStatus(404);
+});
+
+it('creates a prompt', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $payload = ['content' => 'Example prompt', 'name' => 'Prompt'];
+
+    $this->postJson('/api/prompts', $payload)
+        ->assertStatus(201)
+        ->assertJson(['content' => 'Example prompt', 'team_id' => $team->id]);
+
+    $this->assertDatabaseHas('prompts', ['content' => 'Example prompt', 'team_id' => $team->id]);
+});
+
+it('updates a prompt', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $this->putJson("/api/prompts/{$prompt->id}", ['content' => 'Updated'])
+        ->assertStatus(200)
+        ->assertJson(['id' => $prompt->id, 'content' => 'Updated']);
+
+    $this->assertDatabaseHas('prompts', ['id' => $prompt->id, 'content' => 'Updated']);
+});
+
+it('deletes a prompt', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $this->deleteJson("/api/prompts/{$prompt->id}")
+        ->assertStatus(204);
+
+    $this->assertDatabaseMissing('prompts', ['id' => $prompt->id]);
+});

--- a/tests/Feature/Prompt/PromptGeneratorControllerTest.php
+++ b/tests/Feature/Prompt/PromptGeneratorControllerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\Team;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('requires a domain to generate prompts', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $this->postJson('/api/generate-prompts', [])
+        ->assertStatus(422);
+});

--- a/tests/Feature/Prompt/PromptResponsesControllerTest.php
+++ b/tests/Feature/Prompt/PromptResponsesControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\Prompt;
+use App\Models\Response;
+use App\Models\Team;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('lists responses for a prompt', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+    $responses = Response::factory()->count(2)->for($prompt)->create();
+
+    $this->getJson("/api/prompts/{$prompt->id}/responses")
+        ->assertStatus(200)
+        ->assertJsonCount(2)
+        ->assertJsonPath('0.id', $responses[0]->id)
+        ->assertJsonPath('1.id', $responses[1]->id);
+});

--- a/tests/Feature/Prompt/PromptRunBatchControllerTest.php
+++ b/tests/Feature/Prompt/PromptRunBatchControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\Prompt;
+use App\Models\Team;
+use App\Services\JobDispatcherService;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns 404 when no prompts exist', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $this->postJson('/api/prompt-run-batch')
+        ->assertStatus(404)
+        ->assertJson(['message' => 'No prompts found to run']);
+});
+
+it('dispatches a job to run all prompts', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompts = Prompt::factory()->count(3)->for($team)->create();
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $mock->shouldReceive('dispatch')->once();
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $this->postJson('/api/prompt-run-batch', ['count' => 2])
+        ->assertStatus(200)
+        ->assertJson([
+            'prompts_count' => $prompts->count(),
+            'expected_jobs' => $prompts->count() * 2,
+        ]);
+});

--- a/tests/Feature/Prompt/PromptRunControllerTest.php
+++ b/tests/Feature/Prompt/PromptRunControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\Prompt;
+use App\Models\Team;
+use App\Services\JobDispatcherService;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('dispatches a job to run a prompt', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $mock->shouldReceive('dispatch')->once()->andReturn(['id' => 'job']);
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $this->postJson("/api/prompts/{$prompt->id}/run")
+        ->assertStatus(200)
+        ->assertJsonPath('prompt.id', $prompt->id)
+        ->assertJsonPath('job_status.id', 'job');
+});
+
+it('dispatches a batch when multiple runs are requested', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $mock->shouldReceive('dispatchBatch')->once()->andReturn(['id' => 'batch']);
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $this->postJson("/api/prompts/{$prompt->id}/run", ['count' => 2])
+        ->assertStatus(200)
+        ->assertJsonPath('prompt.id', $prompt->id)
+        ->assertJsonPath('batch.id', 'batch');
+});


### PR DESCRIPTION
## Summary
- add feature tests covering Prompt CRUD endpoints
- test listing responses for prompts
- add tests verifying prompt runner dispatch behavior
- include batch run tests and generator validation

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c7cc304008323a18737e5deabf53e