### PR TITLE
Add organization controller tests

### DIFF
--- a/tests/Feature/Organization/OrganizationCompetitorControllerTest.php
+++ b/tests/Feature/Organization/OrganizationCompetitorControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Prompt;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\JobStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('returns not found when there are no prompts', function () {
+    Bus::fake();
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/organizations-generate-competitors');
+
+    $response->assertStatus(404);
+});
+
+it('dispatches competitor jobs for each prompt', function () {
+    Bus::fake();
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $prompt1 = Prompt::factory()->for($team)->create();
+    $prompt2 = Prompt::factory()->for($team)->create();
+
+    $response = $this->postJson('/api/organizations-generate-competitors');
+
+    $response->assertStatus(200)
+        ->assertJson([
+            'prompts_count' => 2,
+            'total_jobs' => 2,
+        ]);
+
+    expect(JobStatus::where('trackable_type', Prompt::class)->count())->toBe(2);
+});
+

--- a/tests/Feature/Organization/OrganizationControllerTest.php
+++ b/tests/Feature/Organization/OrganizationControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Keyword;
+use App\Models\JobStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('lists organizations for the current team', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+
+    $org1 = Organization::factory()->for($team)->owned()->create();
+    $org2 = Organization::factory()->for($team)->create();
+    $otherOrg = Organization::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/organizations');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(2)
+        ->assertJsonFragment(['id' => $org1->id])
+        ->assertJsonFragment(['id' => $org2->id])
+        ->assertJsonMissing(['id' => $otherOrg->id]);
+});
+
+it('creates an organization with keywords for name and website', function () {
+    Bus::fake();
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/organizations', [
+        'name' => 'Acme',
+        'website' => 'acme.com',
+        'is_competitor' => true,
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJson([
+            'name' => 'Acme',
+            'website' => 'acme.com',
+            'team_id' => $team->id,
+        ]);
+
+    $organizationId = $response->json('id');
+
+    expect(Organization::find($organizationId))->not->toBeNull();
+    expect(Keyword::where('organization_id', $organizationId)->count())->toBe(2);
+    expect(JobStatus::where('team_id', $team->id)->where('trackable_type', Keyword::class)->count())->toBe(2);
+});
+
+it('shows an organization belonging to the team', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    $organization = Organization::factory()->for($team)->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson("/api/organizations/{$organization->id}");
+
+    $response->assertStatus(200)
+        ->assertJson(['id' => $organization->id]);
+});
+
+it('returns unauthorized when viewing another team\'s organization', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    $otherOrganization = Organization::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson("/api/organizations/{$otherOrganization->id}");
+
+    $response->assertStatus(403);
+});
+
+it('updates an organization belonging to the team', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    $organization = Organization::factory()->for($team)->create(['name' => 'Old']);
+
+    Sanctum::actingAs($user);
+
+    $response = $this->putJson("/api/organizations/{$organization->id}", [
+        'name' => 'Updated',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJson(['name' => 'Updated']);
+
+    expect($organization->refresh()->name)->toBe('Updated');
+});
+
+it('deletes a competitor organization', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    $organization = Organization::factory()->for($team)->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->deleteJson("/api/organizations/{$organization->id}");
+
+    $response->assertStatus(204);
+
+    expect(Organization::find($organization->id))->toBeNull();
+});
+
+it('does not delete the default organization', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    $organization = Organization::factory()->for($team)->owned()->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->deleteJson("/api/organizations/{$organization->id}");
+
+    $response->assertStatus(422);
+
+    expect(Organization::find($organization->id))->not->toBeNull();
+});
+

--- a/tests/Feature/Organization/OrganizationOnboardControllerTest.php
+++ b/tests/Feature/Organization/OrganizationOnboardControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Keyword;
+use App\Models\JobStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('onboards a new organization and dispatches a generate phrases job', function () {
+    Bus::fake();
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/organizations-onboard', [
+        'name' => 'Acme',
+        'website' => 'acme.com',
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJson(['name' => 'Acme']);
+
+    $organizationId = $response->json('id');
+
+    expect(Organization::find($organizationId))->not->toBeNull();
+    expect(Keyword::where('organization_id', $organizationId)->count())->toBe(2);
+    expect(JobStatus::where('trackable_type', Organization::class)->count())->toBe(1);
+});
+

--- a/tests/Feature/Organization/OrganizationSearchControllerTest.php
+++ b/tests/Feature/Organization/OrganizationSearchControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Services\BrandFetchService;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('returns search results from the brand fetch service', function () {
+    $mock = Mockery::mock(BrandFetchService::class);
+    $mock->shouldReceive('searchBrands')->with('acme')->once()->andReturn([
+        ['name' => 'Acme Inc'],
+    ]);
+    $this->app->instance(BrandFetchService::class, $mock);
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/organization-search?query=acme');
+
+    $response->assertStatus(200)
+        ->assertJson(['results' => [['name' => 'Acme Inc']]]);
+});
+
+it('returns empty results when the query is missing', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/organization-search');
+
+    $response->assertStatus(200)
+        ->assertJson(['results' => []]);
+});
+
+it('returns brand details using the brand fetch service', function () {
+    $mock = Mockery::mock(BrandFetchService::class);
+    $mock->shouldReceive('getBrandDetails')->with('acme.com')->once()->andReturn([
+        'domain' => 'acme.com',
+    ]);
+    $this->app->instance(BrandFetchService::class, $mock);
+
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/brand-details?identifier=acme.com');
+
+    $response->assertStatus(200)
+        ->assertJson(['details' => ['domain' => 'acme.com']]);
+});
+
+it('requires identifier when requesting brand details', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/brand-details');
+
+    $response->assertStatus(422);
+});
+

--- a/tests/Feature/Organization/OrganizationVisibilityControllerTest.php
+++ b/tests/Feature/Organization/OrganizationVisibilityControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Organization;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Keyword;
+use App\Models\Prompt;
+use App\Models\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+it('calculates visibility for organizations', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->for($user, 'owner')->create();
+    Sanctum::actingAs($user);
+
+    $org1 = Organization::factory()->for($team)->owned()->create(['name' => 'Org1']);
+    $org2 = Organization::factory()->for($team)->create(['name' => 'Org2']);
+
+    $keyword1 = Keyword::factory()->for($team)->for($org1, 'organization')->create();
+    $keyword2 = Keyword::factory()->for($team)->for($org2, 'organization')->create();
+
+    $prompt = Prompt::factory()->for($team)->create();
+
+    $response1 = Response::factory()->for($prompt)->create();
+    $response1->keywords()->attach($keyword1->id);
+
+    $response2 = Response::factory()->for($prompt)->create();
+    $response2->keywords()->attach($keyword2->id);
+
+    $response = $this->getJson('/api/organization-visibility');
+
+    $response->assertStatus(200)
+        ->assertJsonFragment(['id' => $org1->id, 'visibility' => 50.0])
+        ->assertJsonFragment(['id' => $org2->id, 'visibility' => 50.0]);
+});
+


### PR DESCRIPTION
## Summary
- add OrganizationControllerTest covering CRUD
- add onboarding, competitor generation, search and visibility tests

## Testing
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c7cdb862883239835609c5070b39c