### PR TITLE
Add JobStatusController Pest tests

### DIFF
--- a/database/factories/JobStatusFactory.php
+++ b/database/factories/JobStatusFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\JobStatus;
+use App\Models\Team;
+use App\Models\Prompt;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<JobStatus>
+ */
+class JobStatusFactory extends Factory
+{
+    protected $model = JobStatus::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'job_id' => (string) Str::uuid(),
+            'job_class' => 'App\\Jobs\\ExampleJob',
+            'job_batch_id' => null,
+            'status' => $this->faker->randomElement(['pending', 'processing', 'completed', 'failed']),
+            'output' => null,
+            'error' => null,
+            'progress' => $this->faker->numberBetween(0, 100),
+            'trackable_id' => Prompt::factory(),
+            'trackable_type' => Prompt::class,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/tests/Feature/Job/JobStatusControllerTest.php
+++ b/tests/Feature/Job/JobStatusControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\JobStatus;
+use App\Models\Team;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns job statuses for the authenticated team', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    JobStatus::factory()->count(3)->for($team)->create();
+    $otherTeam = Team::factory()->create();
+    JobStatus::factory()->count(2)->for($otherTeam)->create();
+
+    $response = $this->getJson('/api/team-jobs');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(3)
+        ->assertJson(fn ($json) =>
+            $json->each(fn ($item) =>
+                $item->where('team_id', $team->id)
+            )
+        );
+});
+
+it('limits results to 100 in descending order', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    $jobs = JobStatus::factory()->for($team)
+        ->count(105)
+        ->sequence(fn ($sequence) => ['created_at' => now()->addSeconds($sequence->index)])
+        ->create();
+
+    $response = $this->getJson('/api/team-jobs');
+    $response->assertStatus(200)
+        ->assertJsonCount(100)
+        ->assertJsonPath('0.id', $jobs->last()->id);
+});


### PR DESCRIPTION
## Summary
- add factory for JobStatus model
- add feature tests covering JobStatusController

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c7ced7d50832394476944cf63bfd7