### PR TITLE
Add RunPromptJob unit tests

### DIFF
--- a/tests/Unit/RunAllPromptsJobTest.php
+++ b/tests/Unit/RunAllPromptsJobTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Jobs\RunAllPromptsJob;
+use App\Jobs\RunPromptJob;
+use App\Models\Prompt;
+use App\Models\Team;
+use App\Services\JobDispatcherService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('dispatches a batch of prompt jobs', function () {
+    $team = Team::factory()->create();
+    $prompts = Prompt::factory()->count(2)->for($team)->create();
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $mock->shouldReceive('dispatchBatch')
+        ->once()
+        ->with(
+            Mockery::on(fn ($models) => $models->pluck('id')->sort()->values()->all() === $prompts->pluck('id')->sort()->values()->all()),
+            Mockery::on(fn ($jobs) => count($jobs) === $prompts->count() * 2 && collect($jobs)->every(fn ($job) => $job instanceof RunPromptJob)),
+            Mockery::type('array')
+        )
+        ->andReturn((object) ['id' => 'batch']);
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $job = new RunAllPromptsJob($prompts->first(), $team->id, ['openai'], 2);
+    $job->handle($mock);
+});
+
+it('completes when no prompts exist', function () {
+    $team = Team::factory()->create();
+
+    $mock = Mockery::mock(JobDispatcherService::class);
+    $mock->shouldReceive('dispatchBatch')->never();
+    $this->app->instance(JobDispatcherService::class, $mock);
+
+    $job = new RunAllPromptsJob(new Prompt(), $team->id);
+    $job->handle($mock);
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Unit/RunPromptJobTest.php
+++ b/tests/Unit/RunPromptJobTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Jobs\RunPromptJob;
+use App\Models\Team;
+use App\Models\Organization;
+use App\Models\Keyword;
+use App\Models\Prompt;
+use App\Models\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('attaches found keywords to response and prompt', function () {
+    $team = Team::factory()->create();
+    $org = Organization::factory()->owned()->for($team)->create();
+
+    $keyword = Keyword::factory()->for($team)->for($org)->create(['name' => 'Acme']);
+    $missing = Keyword::factory()->for($team)->for($org)->create(['name' => 'Missing']);
+
+    $prompt = Prompt::factory()->for($team)->create();
+    $response = Response::factory()->for($prompt)->create(['content' => 'Acme is great']);
+
+    $job = new RunPromptJob($prompt, [], $team->id);
+
+    $method = new ReflectionMethod(RunPromptJob::class, 'checkForKeywords');
+    $method->setAccessible(true);
+    $method->invoke($job, $response, $prompt);
+
+    $this->assertDatabaseHas('keyword_prompt', [
+        'keyword_id' => $keyword->id,
+        'prompt_id' => $prompt->id,
+        'count' => 1,
+    ]);
+
+    $this->assertDatabaseMissing('keyword_prompt', [
+        'keyword_id' => $missing->id,
+        'prompt_id' => $prompt->id,
+    ]);
+
+    $this->assertDatabaseHas('keyword_response', [
+        'keyword_id' => $keyword->id,
+        'response_id' => $response->id,
+    ]);
+});
+
+it('increments existing keyword prompt counts', function () {
+    $team = Team::factory()->create();
+    $org = Organization::factory()->owned()->for($team)->create();
+
+    $keyword = Keyword::factory()->for($team)->for($org)->create(['name' => 'Acme']);
+    $prompt = Prompt::factory()->for($team)->create();
+    $prompt->keywords()->attach($keyword->id, ['count' => 1, 'last_found_at' => now()]);
+
+    $response = Response::factory()->for($prompt)->create(['content' => 'ACME again']);
+
+    $job = new RunPromptJob($prompt, [], $team->id);
+
+    $method = new ReflectionMethod(RunPromptJob::class, 'checkForKeywords');
+    $method->setAccessible(true);
+    $method->invoke($job, $response, $prompt);
+
+    $this->assertDatabaseHas('keyword_prompt', [
+        'keyword_id' => $keyword->id,
+        'prompt_id' => $prompt->id,
+        'count' => 2,
+    ]);
+});


### PR DESCRIPTION
## Summary
- cover `RunPromptJob::checkForKeywords()` with unit tests
- add unit tests for `RunAllPromptsJob`

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c9762d54c8323a8903502c4cf9293