### PR TITLE
Add ability to cancel queued jobs

### DIFF
--- a/app/Http/Controllers/JobStatusController.php
+++ b/app/Http/Controllers/JobStatusController.php
@@ -28,4 +28,28 @@ class JobStatusController extends Controller
 
         return response()->json($jobStatuses);
     }
+
+    /**
+     * Cancel all pending jobs for the current team.
+     */
+    public function cancelTeamJobs(Request $request)
+    {
+        $teamId = Auth::user()->current_team_id;
+
+        $pendingJobs = JobStatus::where('team_id', $teamId)
+            ->where('status', 'pending')
+            ->get();
+
+        $batchIds = $pendingJobs->pluck('job_batch_id')->filter()->unique();
+
+        foreach ($batchIds as $batchId) {
+            Bus::findBatch($batchId)?->cancel();
+        }
+
+        JobStatus::where('team_id', $teamId)
+            ->where('status', 'pending')
+            ->update(['status' => 'cancelled']);
+
+        return response()->json(['message' => 'Jobs cancelled']);
+    }
 }

--- a/app/Jobs/CheckKeywordInPastResponsesJob.php
+++ b/app/Jobs/CheckKeywordInPastResponsesJob.php
@@ -59,11 +59,14 @@ class CheckKeywordInPastResponsesJob extends TrackableJob
 	 *
 	 * @return void
 	 */
-	public function handle()
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Checking keyword in past responses');
+        public function handle()
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Checking keyword in past responses');
 
 			// Get all responses for prompts in the same team
 			$responses = Response::whereHas('prompt', function ($query) {

--- a/app/Jobs/FindCompetitorsInResponseJob.php
+++ b/app/Jobs/FindCompetitorsInResponseJob.php
@@ -62,11 +62,14 @@ class FindCompetitorsInResponseJob extends TrackableJob
 	 *
 	 * @return void
 	 */
-	public function handle()
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Finding competitors in response');
+        public function handle()
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Finding competitors in response');
 
 			// Update progress
 			$this->updateJobProgress(10, 'Finding competitors in response');

--- a/app/Jobs/GeneratePhrases.php
+++ b/app/Jobs/GeneratePhrases.php
@@ -61,11 +61,14 @@ class GeneratePhrases extends TrackableJob
 	 * @param JobDispatcherService $jobDispatcher
 	 * @return void
 	 */
-	public function handle(JobDispatcherService $jobDispatcher)
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Generating keyword terms for ' . $this->model->name);
+        public function handle(JobDispatcherService $jobDispatcher)
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Generating keyword terms for ' . $this->model->name);
 
 			$searchApiTool = new SearchApiTool();
 

--- a/app/Jobs/GeneratePrompt.php
+++ b/app/Jobs/GeneratePrompt.php
@@ -65,11 +65,14 @@ class GeneratePrompt extends TrackableJob
 	 *
 	 * @return void
 	 */
-	public function handle(JobDispatcherService $jobDispatcher)
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Generating prompt from term "' . $this->term . '"');
+        public function handle(JobDispatcherService $jobDispatcher)
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Generating prompt from term "' . $this->term . '"');
 
 			$searchApiTool = new SearchApiTool();
 

--- a/app/Jobs/RunAllPromptsJob.php
+++ b/app/Jobs/RunAllPromptsJob.php
@@ -70,11 +70,14 @@ class RunAllPromptsJob extends TrackableJob
 	 *
 	 * @return void
 	 */
-	public function handle(JobDispatcherService $jobDispatcher)
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Running all prompts');
+        public function handle(JobDispatcherService $jobDispatcher)
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Running all prompts');
 
 			// Update progress
 			$this->updateJobProgress(10, 'Fetching prompts');

--- a/app/Jobs/RunPromptJob.php
+++ b/app/Jobs/RunPromptJob.php
@@ -89,11 +89,14 @@ class RunPromptJob extends TrackableJob
 	 *
 	 * @return void
 	 */
-	public function handle(JobDispatcherService $jobDispatcher)
-	{
-		try {
-			// Mark the job as started
-			$this->markJobAsStarted('Running a prompt');
+        public function handle(JobDispatcherService $jobDispatcher)
+        {
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
+                        // Mark the job as started
+                        $this->markJobAsStarted('Running a prompt');
 
 			// If no providers specified, use all
 			if (!$this->providers) {

--- a/app/Jobs/TrackableJob.php
+++ b/app/Jobs/TrackableJob.php
@@ -38,14 +38,26 @@ abstract class TrackableJob implements ShouldQueue
 	 *
 	 * @return \App\Models\JobStatus|null
 	 */
-	protected function getJobStatus()
-	{
-		if (!$this->jobStatusId) {
-			return null;
-		}
+    protected function getJobStatus()
+    {
+        if (!$this->jobStatusId) {
+            return null;
+        }
 
-		return JobStatus::where('job_id', $this->jobStatusId)->first();
-	}
+        return JobStatus::where('job_id', $this->jobStatusId)->first();
+    }
+
+    /**
+     * Determine if the job has been cancelled.
+     *
+     * @return bool
+     */
+    protected function isCancelled()
+    {
+        $status = $this->getJobStatus();
+
+        return $status && $status->status === 'cancelled';
+    }
 
 	/**
 	 * Update the job status.

--- a/app/Models/JobStatus.php
+++ b/app/Models/JobStatus.php
@@ -67,4 +67,12 @@ class JobStatus extends Model
     {
         return $query->where('status', 'failed');
     }
+
+    /**
+     * Scope a query to only include cancelled jobs.
+     */
+    public function scopeCancelled($query)
+    {
+        return $query->where('status', 'cancelled');
+    }
 }

--- a/database/factories/JobStatusFactory.php
+++ b/database/factories/JobStatusFactory.php
@@ -22,7 +22,7 @@ class JobStatusFactory extends Factory
             'job_id' => (string) Str::uuid(),
             'job_class' => 'App\\Jobs\\ExampleJob',
             'job_batch_id' => null,
-            'status' => $this->faker->randomElement(['pending', 'processing', 'completed', 'failed']),
+            'status' => $this->faker->randomElement(['pending', 'processing', 'completed', 'failed', 'cancelled']),
             'output' => null,
             'error' => null,
             'progress' => $this->faker->numberBetween(0, 100),

--- a/resources/js/components/jobs/JobStatusList.vue
+++ b/resources/js/components/jobs/JobStatusList.vue
@@ -175,11 +175,13 @@ function getStatusClass(status) {
 			return 'bg-blue-100 text-blue-800'
 		case 'completed':
 			return 'bg-green-100 text-green-800'
-		case 'failed':
-			return 'bg-red-100 text-red-800'
-		default:
-			return 'bg-neutral-100 text-neutral-800'
-	}
+                case 'failed':
+                        return 'bg-red-100 text-red-800'
+                case 'cancelled':
+                        return 'bg-red-100 text-red-800'
+                default:
+                        return 'bg-neutral-100 text-neutral-800'
+        }
 }
 
 function formatDate(dateString) {
@@ -202,12 +204,14 @@ function getBatchStatus(batch) {
 	// Calculate batch status based on jobs
 	const statuses = batch.jobs.map((job) => job.status)
 
-	if (statuses.includes('failed')) {
-		return 'Failed'
-	} else if (statuses.includes('processing')) {
-		return 'Processing'
-	} else if (statuses.includes('pending')) {
-		return 'Pending'
+        if (statuses.includes('failed')) {
+                return 'Failed'
+        } else if (statuses.includes('cancelled')) {
+                return 'Cancelled'
+        } else if (statuses.includes('processing')) {
+                return 'Processing'
+        } else if (statuses.includes('pending')) {
+                return 'Pending'
 	} else if (statuses.every((status) => status === 'completed')) {
 		return 'Completed'
 	} else {

--- a/resources/js/components/jobs/JobStatusSheet.vue
+++ b/resources/js/components/jobs/JobStatusSheet.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import Sheet from '@/components/ui/Sheet.vue'
 import JobStatusList from '@/components/jobs/JobStatusList.vue'
+import { useJobStatusStore } from '@/stores/jobStatusStore'
 
 const props = defineProps({
 	isOpen: {
@@ -13,14 +14,25 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 
 const closeSheet = () => {
-	emit('close')
+        emit('close')
+}
+
+const jobStatusStore = useJobStatusStore()
+
+async function cancelJobs() {
+        await jobStatusStore.cancelTeamJobs()
 }
 </script>
 
 <template>
-	<Sheet :is-open="isOpen" @close="closeSheet" position="right" title="Runs">
-		<div class="w-full xl:w-[800px] md:p-4">
-			<JobStatusList :autoRefresh="true" :refreshInterval="1000" />
-		</div>
-	</Sheet>
+        <Sheet :is-open="isOpen" @close="closeSheet" position="right" title="Runs">
+                <template #header-actions>
+                        <button @click="cancelJobs" class="px-3 py-1 text-sm rounded bg-red-600 text-white hover:bg-red-700">
+                                Cancel Jobs
+                        </button>
+                </template>
+                <div class="w-full xl:w-[800px] md:p-4">
+                        <JobStatusList :autoRefresh="true" :refreshInterval="1000" />
+                </div>
+        </Sheet>
 </template>

--- a/resources/js/components/ui/Sheet.vue
+++ b/resources/js/components/ui/Sheet.vue
@@ -49,18 +49,21 @@ onUnmounted(() => {
         :class="isOpen ? 'translate-x-0' : position === 'right' ? 'translate-x-full' : '-translate-x-full'"
         @click.stop
       >
-        <div class="px-6 py-3 border-b border-neutral-200 flex justify-between items-center">
+        <div class="px-6 py-3 border-b border-neutral-200 flex justify-between items-center gap-2">
           <h3 class="text-lg font-medium text-neutral-900" v-if="title">
             {{ title }}
           </h3>
-          <button 
-            @click="closeSheet" 
-            class="text-neutral-400 hover:text-neutral-600 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-          </button>
+          <div class="flex items-center gap-2">
+            <slot name="header-actions"></slot>
+            <button
+              @click="closeSheet"
+              class="text-neutral-400 hover:text-neutral-600 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="flex-1 p-6 overflow-y-auto">
           <slot></slot>

--- a/resources/js/stores/jobStatusStore.js
+++ b/resources/js/stores/jobStatusStore.js
@@ -49,10 +49,10 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		startAutoRefresh(1500)
 	}
 
-	async function fetchTeamJobs() {
-		console.log('Fetching team jobs...')
-		loading.value = true
-		error.value = null
+        async function fetchTeamJobs() {
+                console.log('Fetching team jobs...')
+                loading.value = true
+                error.value = null
 
 		try {
 			const response = await api.get('/team-jobs')
@@ -63,8 +63,18 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 			throw err
 		} finally {
 			loading.value = false
-		}
-	}
+                }
+        }
+
+        async function cancelTeamJobs() {
+                try {
+                        await api.post('/team-jobs/cancel')
+                        await fetchTeamJobs()
+                } catch (err) {
+                        error.value = 'Failed to cancel jobs: ' + (err.response?.data?.error || err.message)
+                        throw err
+                }
+        }
 
 	function hasActiveJobs() {
 		return jobs.value.some((job) => job.status === 'pending' || job.status === 'processing')
@@ -116,9 +126,10 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		pollTeamJobs,
 		fetchTeamJobs,
 		hasActiveJobs,
-		startAutoRefresh,
-		stopAutoRefresh,
-		getJobById,
-		getBatchById
-	}
+                startAutoRefresh,
+                stopAutoRefresh,
+                getJobById,
+                getBatchById,
+                cancelTeamJobs
+        }
 })

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,6 +86,7 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::delete('teams/{team}/members/{user}', [TeamController::class, 'removeMember']);
 	Route::put('teams/{team}/members/{user}/role', [TeamController::class, 'updateMemberRole']);
 
-	// Job status routes
-	Route::get('/team-jobs', [JobStatusController::class, 'getTeamJobs']);
+        // Job status routes
+        Route::get('/team-jobs', [JobStatusController::class, 'getTeamJobs']);
+        Route::post('/team-jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
 });

--- a/tests/Feature/Job/JobStatusControllerTest.php
+++ b/tests/Feature/Job/JobStatusControllerTest.php
@@ -42,3 +42,17 @@ it('limits results to 100 in descending order', function () {
         ->assertJsonCount(100)
         ->assertJsonPath('0.id', $jobs->last()->id);
 });
+
+it('cancels pending jobs for the authenticated team', function () {
+    $team = Team::factory()->create();
+    $user = $team->owner;
+    Sanctum::actingAs($user);
+
+    JobStatus::factory()->count(2)->for($team)->state(['status' => 'pending'])->create();
+
+    $response = $this->postJson('/api/team-jobs/cancel');
+
+    $response->assertStatus(200);
+
+    expect(JobStatus::where('team_id', $team->id)->where('status', 'cancelled')->count())->toBe(2);
+});


### PR DESCRIPTION
## Summary
- allow custom header actions in `Sheet.vue`
- show a `Cancel Jobs` button in `JobStatusSheet.vue`
- add cancel endpoint in `JobStatusController`
- update `routes/api.php` for new endpoint
- add store method to cancel jobs
- support cancelled status in UI and factories
- add helper and checks for cancelled jobs in queue
- tests for cancelling jobs

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e1f9df5ac83238807a7e67aed2784