### PR TITLE
Implement team deletion and cleanup

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -142,17 +142,25 @@ class TeamController extends Controller
 	/**
 	 * Remove the specified team from storage.
 	 */
-	public function destroy(Team $team)
-	{
-		// Only the owner can delete a team
-		if ($team->owner_id !== Auth::id()) {
-			return response()->json(['message' => 'Unauthorized'], 403);
-		}
+        public function destroy(Team $team)
+        {
+                // Only the owner can delete a team
+                if ($team->owner_id !== Auth::id()) {
+                        return response()->json(['message' => 'Unauthorized'], 403);
+                }
 
-		$team->delete();
+                $team->delete();
 
-		return response()->json(['message' => 'Team deleted successfully']);
-	}
+                return response()->json(['message' => 'Team deleted successfully']);
+        }
+
+        /**
+         * Alias for destroy to support DELETE /teams/{team} via "delete" route if needed.
+         */
+        public function delete(Team $team)
+        {
+                return $this->destroy($team);
+        }
 
 	/**
 	 * Invite a user to the team.

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
+use App\Models\JobStatus;
 
 class Team extends Model
 {
@@ -75,8 +77,58 @@ class Team extends Model
 	/**
 	 * Get the organizations that belong to the team.
 	 */
-	public function organizations(): HasMany
-	{
-		return $this->hasMany(Organization::class);
-	}
+        public function organizations(): HasMany
+        {
+                return $this->hasMany(Organization::class);
+        }
+
+        /**
+         * Get the job statuses that belong to the team.
+         */
+        public function jobStatuses(): HasMany
+        {
+                return $this->hasMany(JobStatus::class);
+        }
+
+        /**
+         * The "booted" method of the model.
+         * Remove related data and queued jobs when deleting a team.
+         */
+        protected static function booted()
+        {
+                static::deleting(function (Team $team) {
+                        // Detach all users from the team
+                        $team->users()->detach();
+
+                        // Delete related models via Eloquent so model events fire
+                        $team->prompts()->get()->each->delete();
+                        $team->keywords()->get()->each->delete();
+                        $team->organizations()->get()->each->delete();
+
+                        // Remove queued job data
+                        $jobIds = $team->jobStatuses()->pluck('job_id')->toArray();
+                        $batchIds = $team->jobStatuses()->whereNotNull('job_batch_id')->pluck('job_batch_id')->toArray();
+
+                        // Delete job status records
+                        $team->jobStatuses()->delete();
+
+                        if (!empty($jobIds)) {
+                                DB::table('jobs')->where(function ($query) use ($jobIds) {
+                                        foreach ($jobIds as $id) {
+                                                $query->orWhere('payload', 'like', '%' . $id . '%');
+                                        }
+                                })->delete();
+
+                                DB::table('failed_jobs')->where(function ($query) use ($jobIds) {
+                                        foreach ($jobIds as $id) {
+                                                $query->orWhere('payload', 'like', '%' . $id . '%');
+                                        }
+                                })->delete();
+                        }
+
+                        if (!empty($batchIds)) {
+                                DB::table('job_batches')->whereIn('id', $batchIds)->delete();
+                        }
+                });
+        }
 }

--- a/resources/js/components/ui/Button.vue
+++ b/resources/js/components/ui/Button.vue
@@ -2,51 +2,51 @@
 import { Primitive } from 'reka-ui'
 
 const props = defineProps({
-  variant: {
-    type: String,
-    default: 'default'
-  },
-  size: {
-    type: String,
-    default: 'default'
-  },
-  as: {
-    type: String,
-    default: 'button'
-  },
-  asChild: Boolean
+	variant: {
+		type: String,
+		default: 'default'
+	},
+	size: {
+		type: String,
+		default: 'default'
+	},
+	as: {
+		type: String,
+		default: 'button'
+	},
+	asChild: Boolean
 })
 
 const variants = {
-    default: 'bg-black text-white shadow-xs hover:bg-black/80',
-    destructive: 'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20',
-    outline: 'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
-    secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-    ghost: 'hover:bg-accent hover:text-accent-foreground',
-    link: 'text-black underline-offset-4 hover:underline',
-    neutral: 'bg-neutral-200 text-neutral-800 hover:bg-neutral-100',
-    dark: 'bg-neutral-800 text-white hover:bg-neutral-700',
-    primary: 'bg-blue-600 text-white hover:bg-blue-700',
-    success: 'bg-green-600 text-white hover:bg-green-700',
-    muted: 'bg-neutral-600 text-white hover:bg-neutral-700',
+	default: 'bg-black text-white shadow-xs hover:bg-black/80',
+	destructive: 'bg-red-600 text-white shadow-xs hover:bg-red-600/80 focus-visible:ring-red/20',
+	outline: 'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
+	secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+	ghost: 'hover:bg-accent hover:text-accent-foreground',
+	link: 'text-black underline-offset-4 hover:underline',
+	neutral: 'bg-neutral-200 text-neutral-800 hover:bg-neutral-100',
+	dark: 'bg-neutral-800 text-white hover:bg-neutral-700',
+	primary: 'bg-blue-600 text-white hover:bg-blue-700',
+	success: 'bg-green-600 text-white hover:bg-green-700',
+	muted: 'bg-neutral-600 text-white hover:bg-neutral-700'
 }
 
 const sizes = {
-    default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-    sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-    lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-    icon: 'size-9',
+	default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+	sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+	lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+	icon: 'size-9'
 }
 </script>
 
 <template>
-  <Primitive
-    data-slot="button"
-    :as="as"
-    :as-child="asChild"
-    :class="`${variants[variant]} ${sizes[size]}`"
-    class="'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive'"
-  >
-    <slot />
-  </Primitive>
+	<Primitive
+		data-slot="button"
+		:as="as"
+		:as-child="asChild"
+		:class="`${variants[variant]} ${sizes[size]}`"
+		class="'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive'"
+	>
+		<slot />
+	</Primitive>
 </template>

--- a/resources/js/pages/teams/Show.vue
+++ b/resources/js/pages/teams/Show.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useTeamStore } from '@/stores/teamStore'
 import auth from '@/services/auth'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import Button from '@/components/ui/Button.vue'
 
 const route = useRoute()
+const router = useRouter()
 const teamStore = useTeamStore()
 const teamId = computed(() => route.params.id)
 const currentUser = computed(() => auth.getUser())
@@ -77,11 +78,22 @@ const removeMember = async (userId) => {
 }
 
 const updateRole = async (userId, role) => {
-	try {
-		await teamStore.updateMemberRole(teamId.value, userId, { role })
-	} catch (error) {
-		console.error('Error updating role:', error)
-	}
+        try {
+                await teamStore.updateMemberRole(teamId.value, userId, { role })
+        } catch (error) {
+                console.error('Error updating role:', error)
+        }
+}
+
+const deleteTeam = async () => {
+        if (!confirm('Are you sure you want to delete this team? This action cannot be undone.')) return
+
+        try {
+                await teamStore.deleteTeam(teamId.value)
+                router.push('/teams')
+        } catch (error) {
+                console.error('Error deleting team:', error)
+        }
 }
 </script>
 
@@ -104,11 +116,12 @@ const updateRole = async (userId, role) => {
 						<h1 class="text-2xl font-bold">{{ teamStore.currentTeam.name }}</h1>
 						<p class="text-neutral-600 mt-1">Owner: {{ teamStore.currentTeam.owner?.name || 'Unknown' }}</p>
 					</div>
-					<div class="flex space-x-2">
-						<Button v-if="isOwner || isAdmin" @click="showEditModal = true" variant="neutral"> Edit Team </Button>
-						<Button v-if="isOwner || isAdmin" @click="showInviteModal = true" variant="dark"> Invite Member </Button>
-					</div>
-				</div>
+                                        <div class="flex space-x-2">
+                                                <Button v-if="isOwner || isAdmin" @click="showEditModal = true" variant="neutral"> Edit Team </Button>
+                                                <Button v-if="isOwner || isAdmin" @click="showInviteModal = true" variant="dark"> Invite Member </Button>
+                                                <Button v-if="isOwner" @click="deleteTeam" variant="destructive"> Delete Team </Button>
+                                        </div>
+                                </div>
 
 				<!-- Team Members -->
 				<div class="bg-white rounded-lg shadow-sm border border-neutral-200 overflow-hidden">

--- a/resources/js/pages/teams/Show.vue
+++ b/resources/js/pages/teams/Show.vue
@@ -78,22 +78,22 @@ const removeMember = async (userId) => {
 }
 
 const updateRole = async (userId, role) => {
-        try {
-                await teamStore.updateMemberRole(teamId.value, userId, { role })
-        } catch (error) {
-                console.error('Error updating role:', error)
-        }
+	try {
+		await teamStore.updateMemberRole(teamId.value, userId, { role })
+	} catch (error) {
+		console.error('Error updating role:', error)
+	}
 }
 
 const deleteTeam = async () => {
-        if (!confirm('Are you sure you want to delete this team? This action cannot be undone.')) return
+	if (!confirm('Are you sure you want to delete this team? This action cannot be undone.')) return
 
-        try {
-                await teamStore.deleteTeam(teamId.value)
-                router.push('/teams')
-        } catch (error) {
-                console.error('Error deleting team:', error)
-        }
+	try {
+		await teamStore.deleteTeam(teamId.value)
+		router.push('/teams')
+	} catch (error) {
+		console.error('Error deleting team:', error)
+	}
 }
 </script>
 
@@ -116,12 +116,12 @@ const deleteTeam = async () => {
 						<h1 class="text-2xl font-bold">{{ teamStore.currentTeam.name }}</h1>
 						<p class="text-neutral-600 mt-1">Owner: {{ teamStore.currentTeam.owner?.name || 'Unknown' }}</p>
 					</div>
-                                        <div class="flex space-x-2">
-                                                <Button v-if="isOwner || isAdmin" @click="showEditModal = true" variant="neutral"> Edit Team </Button>
-                                                <Button v-if="isOwner || isAdmin" @click="showInviteModal = true" variant="dark"> Invite Member </Button>
-                                                <Button v-if="isOwner" @click="deleteTeam" variant="destructive"> Delete Team </Button>
-                                        </div>
-                                </div>
+					<div class="flex space-x-2">
+						<Button v-if="isOwner || isAdmin" @click="showEditModal = true" variant="neutral"> Edit Team </Button>
+						<Button v-if="isOwner || isAdmin" @click="showInviteModal = true" variant="dark"> Invite Member </Button>
+						<Button v-if="isOwner" @click="deleteTeam" variant="destructive">Delete Team</Button>
+					</div>
+				</div>
 
 				<!-- Team Members -->
 				<div class="bg-white rounded-lg shadow-sm border border-neutral-200 overflow-hidden">

--- a/resources/js/stores/teamStore.js
+++ b/resources/js/stores/teamStore.js
@@ -145,7 +145,7 @@ export const useTeamStore = defineStore('team', {
     },
 
     async removeMember(teamId, userId) {
-	  console.log('Removing member from team ID:', teamId)
+          console.log('Removing member from team ID:', teamId)
       this.isLoading = true;
       this.error = null;
 
@@ -156,6 +156,29 @@ export const useTeamStore = defineStore('team', {
       } catch (error) {
         this.error = error.response?.data?.message || 'Failed to remove member';
         console.error('Error removing member:', error);
+        throw error;
+      } finally {
+      this.isLoading = false;
+      }
+    },
+
+    async deleteTeam(teamId) {
+          console.log('Deleting team ID:', teamId)
+      this.isLoading = true;
+      this.error = null;
+
+      try {
+        const response = await api.delete(`/teams/${teamId}`);
+        await this.fetchTeams();
+        if (this.currentTeam && this.currentTeam.id === teamId) {
+          this.currentTeam = null;
+          this.members = [];
+          this.pendingMembers = [];
+        }
+        return response;
+      } catch (error) {
+        this.error = error.response?.data?.message || 'Failed to delete team';
+        console.error('Error deleting team:', error);
         throw error;
       } finally {
         this.isLoading = false;


### PR DESCRIPTION
## Summary
- cascade delete job and pivot data when deleting teams
- expose a delete alias endpoint for teams
- add ability to delete team from the frontend
- update team store to call delete API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e21f6328c8323a384342d881e0d75