### PR TITLE
Ensure GeneratePrompt fails when search tool fails

### DIFF
--- a/app/Tools/SearchApiTool.php
+++ b/app/Tools/SearchApiTool.php
@@ -25,7 +25,7 @@ class SearchApiTool extends Tool
             'gl' => 'us',
             'hl' => 'en',
             'api_key' => config('services.searchapi.api_key'),
-        ]);
+        ])->throw();
 
         $results = collect($response->json('organic_results'));
 


### PR DESCRIPTION
## Summary
- fail the SearchApiTool request if the HTTP call is unsuccessful

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f5eed0f6883238055183a275f1a17