### PR TITLE
Add Laravel Dusk and login browser test

### DIFF
--- a/app/Providers/DuskServiceProvider.php
+++ b/app/Providers/DuskServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Dusk\DuskServiceProvider as BaseDuskServiceProvider;
+
+class DuskServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        if ($this->app->environment('local', 'testing')) {
+            $this->app->register(BaseDuskServiceProvider::class);
+        }
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $this->gate();
+    }
+
+    /**
+     * Register the Dusk gate.
+     *
+     * This gate determines who can access Dusk routes in non-local environments.
+     */
+    protected function gate(): void
+    {
+        Gate::define('viewDuskDashboard', function ($user) {
+            return in_array($user->email, [
+                //
+            ]);
+        });
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
             Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         ]);
     })
+    ->withProviders([
+        App\Providers\DuskServiceProvider::class,
+    ])
     ->withExceptions(function (Exceptions $exceptions) {
         //
     })->create();

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "^3.8",
-        "pestphp/pest-plugin-laravel": "^3.2"
+        "pestphp/pest-plugin-laravel": "^3.2",
+        "laravel/dusk": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.dusk.xml
+++ b/phpunit.dusk.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Browser">
+            <directory>tests/Browser</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class LoginTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function user_can_log_in()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret123'),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->visit('/login')
+                    ->type('email', $user->email)
+                    ->type('password', 'secret123')
+                    ->press('Login')
+                    ->waitForLocation('/')
+                    ->assertPathIs('/');
+        });
+    }
+}

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\TestCase as BaseTestCase;
+
+abstract class DuskTestCase extends BaseTestCase
+{
+    use CreatesApplication, DatabaseMigrations;
+
+    /**
+     * Prepare for Dusk test execution.
+     */
+    public static function prepare(): void
+    {
+        static::startChromeDriver();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,9 @@ pest()->extend(Tests\TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 
+pest()->extend(Tests\DuskTestCase::class)
+    ->in('Browser');
+
 /*
 |--------------------------------------------------------------------------
 | Expectations

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- install Laravel Dusk dependency
- register new DuskServiceProvider
- add Dusk configuration and base test classes
- create a basic browser test for logging in

## Testing
- `vendor/bin/pest --configuration=phpunit.dusk.xml` *(fails: No such file or directory)*
- `php artisan dusk` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a482b27c832389e5ae7db1ce0f32