### PR TITLE
Add Article generation via conversations

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -9,6 +9,7 @@ use App\Models\Organization;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Services\ChatService;
+use App\Tools\UpdateArticleTool;
 
 class ArticleController extends Controller
 {
@@ -77,7 +78,9 @@ EOT;
 
         $initialMessage = 'Please start by outlining your strategy for this article.';
 
-        $this->chatService->generateResponse($conversation, $initialMessage, $systemMessage);
+        $updateTool = new UpdateArticleTool($article);
+
+        $this->chatService->generateResponse($conversation, $initialMessage, $systemMessage, [$updateTool]);
 
         return response()->json([
             'article' => $article,

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Article;
+use App\Models\Prompt;
+use App\Models\Conversation;
+use App\Models\Organization;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Services\ChatService;
+
+class ArticleController extends Controller
+{
+    public function __construct(protected ChatService $chatService)
+    {
+    }
+
+    public function store(Request $request, Prompt $prompt)
+    {
+        $teamId = Auth::user()->current_team_id;
+
+        if ($prompt->team_id !== $teamId) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        $organization = Organization::where('team_id', $teamId)
+            ->where('is_competitor', false)
+            ->first();
+
+        if (!$organization) {
+            return response()->json(['message' => 'Organization not found'], 404);
+        }
+
+        $conversation = Conversation::create([
+            'title' => $prompt->name ?? 'Article Conversation',
+        ]);
+
+        $article = Article::create([
+            'team_id' => $teamId,
+            'organization_id' => $organization->id,
+            'prompt_id' => $prompt->id,
+            'conversation_id' => $conversation->id,
+            'title' => $prompt->content,
+        ]);
+
+        $locationText = $organization->location ? " in {$organization->location}" : '';
+
+        $systemMessage = <<<EOT
+You are a helpful, knowledgeable assistant that writes structured, question-and-answer style articles to help businesses increase their visibility in LLM completions for specific prompts (e.g., "best home loan Salt Lake City").
+
+Your responsibilities include:
+- Writing a helpful article that is human readable and editable
+- Optimizing the content for inclusion in LLM-generated answers
+
+Your output must be:
+- Human readable
+- Structured as a Q&A article
+- Written in clear, neutral, helpful language
+- Optimized for inclusion in LLM responses, not just search engines
+
+You can use web search to research the businesses website, high-ranking competitors, awards, reviews, relevant stats or proof points and anything else you need to generate the most effective article possible. If you must ask the user any strategic questions then do so after you have finished writing the article, it can be revised at that point.
+
+Content Guidelines:
+- Directly address the target prompt early in the intro and use close variants naturally throughout the article.
+- Use neutral, expert language. Avoid salesy or exaggerated phrases unless citing a real award or review.
+- Be informative and structured, as if you are answering user questions in an assistant-like tone.
+- Write in a way that is easy for a language model to parse, quote, or summarize.
+- Use specific data when provided (e.g., "Rated 4.8 stars on Google" or "Serving Salt Lake since 1995").
+
+Do Not:
+- Output Markdown
+- Do not write code
+
+Generate a highly optimized article for my organization called {$organization->name} ({$organization->website}){$locationText} in Illinois that will increase my visibility in LLM completions for this prompt: "{$prompt->content}"
+EOT;
+
+        $initialMessage = 'Please start by outlining your strategy for this article.';
+
+        $this->chatService->generateResponse($conversation, $initialMessage, $systemMessage);
+
+        return response()->json([
+            'article' => $article,
+            'conversation' => $conversation,
+        ], 201);
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Article extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'organization_id',
+        'prompt_id',
+        'conversation_id',
+        'title',
+        'outline',
+        'content',
+    ];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function prompt(): BelongsTo
+    {
+        return $this->belongsTo(Prompt::class);
+    }
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+}

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -19,7 +19,7 @@ class ChatService
      * @param string $userMessage
      * @return array
      */
-    public function generateResponse(Conversation $conversation, string $userMessage): array
+    public function generateResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null): array
     {
         // Store the user message
         $userChat = $conversation->chats()->create([
@@ -28,7 +28,7 @@ class ChatService
         ]);
         
         // Get AI response
-        $response = $this->getAiResponse($conversation, $userMessage);
+        $response = $this->getAiResponse($conversation, $userMessage, $systemMessage);
         
         // Store the AI response
         $aiChat = $conversation->chats()->create([
@@ -55,7 +55,7 @@ class ChatService
      * @param string $userMessage
      * @return object
      */
-    private function getAiResponse(Conversation $conversation, string $userMessage): object
+    private function getAiResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null): object
     {
         // Fetch all previous chats in the conversation
         $previousChats = $conversation->chats()->orderBy('created_at', 'asc')->get();
@@ -64,7 +64,7 @@ class ChatService
         $messages = [];
         
         // Add system message
-        $messages[] = new SystemMessage((string)view('prompts.system'));
+        $messages[] = new SystemMessage($systemMessage ?? (string)view('prompts.system'));
         
         // Add all previous messages as context
         foreach ($previousChats as $chat) {

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -6,6 +6,7 @@ use App\Models\Chat;
 use App\Models\Conversation;
 use Prism\Prism\Prism;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
@@ -19,7 +20,7 @@ class ChatService
      * @param string $userMessage
      * @return array
      */
-    public function generateResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null): array
+    public function generateResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null, array $tools = []): array
     {
         // Store the user message
         $userChat = $conversation->chats()->create([
@@ -28,7 +29,7 @@ class ChatService
         ]);
         
         // Get AI response
-        $response = $this->getAiResponse($conversation, $userMessage, $systemMessage);
+        $response = $this->getAiResponse($conversation, $userMessage, $systemMessage, $tools);
         
         // Store the AI response
         $aiChat = $conversation->chats()->create([
@@ -55,7 +56,7 @@ class ChatService
      * @param string $userMessage
      * @return object
      */
-    private function getAiResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null): object
+    private function getAiResponse(Conversation $conversation, string $userMessage, ?string $systemMessage = null, array $tools = []): object
     {
         // Fetch all previous chats in the conversation
         $previousChats = $conversation->chats()->orderBy('created_at', 'asc')->get();
@@ -79,9 +80,14 @@ class ChatService
         $messages[] = new UserMessage($userMessage);
         
         // Generate AI response using Prism with full conversation context
-        return Prism::text()
+        $prism = Prism::text()
             ->using(Provider::OpenAI, 'gpt-4o')
-            ->withMessages($messages)
-            ->asText();
+            ->withMessages($messages);
+
+        if (!empty($tools)) {
+            $prism->withMaxSteps(10)->withTools($tools)->withToolChoice(ToolChoice::Auto);
+        }
+
+        return $prism->asText();
     }
 }

--- a/app/Tools/UpdateArticleTool.php
+++ b/app/Tools/UpdateArticleTool.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Tools;
+
+use Prism\Prism\Tool;
+use App\Models\Article;
+
+class UpdateArticleTool extends Tool
+{
+    public function __construct(private Article $article)
+    {
+        $this
+            ->as('update_article')
+            ->for('Update the article outline or content')
+            ->withStringParameter('outline', 'New outline for the article')
+            ->withStringParameter('content', 'New content for the article')
+            ->using($this);
+    }
+
+    public function __invoke(string $outline = null, string $content = null): string
+    {
+        if ($outline !== null) {
+            $this->article->outline = $outline;
+        }
+        if ($content !== null) {
+            $this->article->content = $content;
+        }
+        $this->article->save();
+
+        return 'Article updated';
+    }
+}

--- a/database/migrations/2025_06_05_000000_create_articles_table.php
+++ b/database/migrations/2025_06_05_000000_create_articles_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('organization_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('prompt_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->string('title')->nullable();
+            $table->text('outline')->nullable();
+            $table->longText('content')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+    }
+};

--- a/resources/js/components/prompts/PromptDetailSheet.vue
+++ b/resources/js/components/prompts/PromptDetailSheet.vue
@@ -46,6 +46,19 @@ const copyPromptToClipboard = async () => {
 	}
 }
 
+const startArticleConversation = async () => {
+        if (!props.promptId) return
+
+        try {
+                const response = await api.post(`/prompts/${props.promptId}/articles`)
+                if (response.conversation?.id) {
+                        window.location.href = `/chat?conversation=${response.conversation.id}`
+                }
+        } catch (error) {
+                console.error('Error starting article conversation:', error)
+        }
+}
+
 // Fetch prompt details when component mounts or promptId changes
 const fetchDetails = async () => {
 	if (props.promptId) {
@@ -110,7 +123,7 @@ watch(() => props.promptId, fetchDetails)
 					<h3 class="text-xl font-medium text-neutral-800 mb-2">Optimize for this prompt</h3>
 					<p class="text-neutral-600 mb-4">Generate an article that can be published on your website and increase visibility for this prompt</p>
 					<div class="flex items-center gap-2">
-						<Button @click="copyPromptToClipboard" class="flex items-center gap-2">
+                                                <Button @click="copyPromptToClipboard" class="flex items-center gap-2">
 							<svg
 								v-if="!isCopied"
 								xmlns="http://www.w3.org/2000/svg"
@@ -144,8 +157,11 @@ watch(() => props.promptId, fetchDetails)
 							</svg>
 							<span v-if="isCopied">Copied to clipboard!</span>
 							<span v-else>Generate article prompt</span>
-						</Button>
-						<a
+                                                </Button>
+                                                <Button @click="startArticleConversation" class="flex items-center gap-2">
+                                                        Start article conversation
+                                                </Button>
+                                                <a
 							href="https://chatgpt.com/g/g-683e71bf9d14819194ee7fe3121bf234-article-writer-for-prompt-visibility"
 							target="_blank"
 							class="inline-flex items-center gap-2 px-4 py-2 text-sm bg-green-50 text-green-700 hover:bg-green-100 border border-green-200 rounded-md font-medium transition-colors"

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\PromptResponsesController;
 use App\Http\Controllers\PromptGeneratorController;
 use App\Http\Controllers\PromptController;
 use App\Http\Controllers\PromptOptimizeController;
+use App\Http\Controllers\ArticleController;
 use App\Http\Controllers\OrganizationVisibilityController;
 use App\Http\Controllers\OrganizationSearchController;
 use App\Http\Controllers\OrganizationOnboardController;
@@ -76,9 +77,10 @@ Route::middleware('auth:sanctum')->group(function () {
 
 	// Prompts
 	Route::resource('prompts', PromptController::class);
-	Route::get('prompts/{prompt}/responses', [PromptResponsesController::class, 'index']);
-	Route::get('prompts/{prompt}/optimize', PromptOptimizeController::class);
-	Route::post('organizations/{organization}/generate-prompts', [PromptGeneratorController::class, 'generate']);
+        Route::get('prompts/{prompt}/responses', [PromptResponsesController::class, 'index']);
+        Route::get('prompts/{prompt}/optimize', PromptOptimizeController::class);
+        Route::post('organizations/{organization}/generate-prompts', [PromptGeneratorController::class, 'generate']);
+        Route::post('prompts/{prompt}/articles', [ArticleController::class, 'store']);
 
 	// Running prompts
 	Route::post('prompts/{prompt}/run', [PromptRunController::class, 'store']);


### PR DESCRIPTION
## Summary
- add `Article` model and migration
- enable custom system prompts in `ChatService`
- add `ArticleController` with endpoint to start article conversation
- expose new route for prompt articles
- allow Prompt detail sheet to start article conversation from frontend

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684121ea5fe48323a9f02e9cbcf377b9