### PR TITLE
Add chat tools for writing articles

### DIFF
--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -52,6 +52,9 @@ class ChatService
 
                 $tools = $this->buildTools($conversation);
                 $toolDefinitions = array_map(fn(ChatTool $t) => $t->definition(), $tools);
+                array_unshift($toolDefinitions, [
+                        'type' => 'web_search',
+                ]);
 
                 $response = $this->client->chat()->create([
                         'model' => 'gpt-4o',

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -35,72 +35,86 @@ class ChatService
                         'content' => $userMessage,
                 ]);
 
-                // Build chat history including system prompt
-                $messages = $conversation->chats()
-                        ->orderBy('created_at')
-                        ->get()
-                        ->map(fn($chat) => [
-                                'role' => $chat->role,
-                                'content' => $chat->content,
-                        ])
-                        ->toArray();
-
-                array_unshift($messages, [
-                        'role' => 'system',
-                        'content' => (string) view('prompts.system'),
-                ]);
-
                 $tools = $this->buildTools($conversation);
                 $toolDefinitions = array_map(fn(ChatTool $t) => $t->definition(), $tools);
-                array_unshift($toolDefinitions, [
-                        'type' => 'web_search',
-                ]);
+                array_unshift($toolDefinitions, ['type' => 'web_search']);
 
-                $response = $this->client->chat()->create([
-                        'model' => 'gpt-4o',
-                        'messages' => $messages,
+                // Determine previous response id if conversation has history
+                $lastResponseChat = $conversation->chats()
+                        ->where('role', 'assistant')
+                        ->whereNotNull('metadata->response_id')
+                        ->orderByDesc('created_at')
+                        ->first();
+
+                $previousId = $lastResponseChat->metadata['response_id'] ?? null;
+                if ($previousId) {
+                        $input = $userMessage;
+                } else {
+                        $input = [
+                                ['role' => 'system', 'content' => (string) view('prompts.system')],
+                                ['role' => 'user', 'content' => $userMessage],
+                        ];
+                }
+
+                $response = $this->client->responses()->create([
+                        'model' => 'gpt-4.1',
+                        'input' => $input,
                         'tools' => $toolDefinitions,
                         'tool_choice' => 'auto',
+                        'previous_response_id' => $previousId,
                 ]);
 
-                $message = $response['choices'][0]['message'];
-                while (isset($message['tool_calls'])) {
-                        $messages[] = $message;
-                        $toolMessages = [];
+                $messageOutput = $this->extractMessage($response);
 
-                        foreach ($message['tool_calls'] as $toolCall) {
-                                $tool = $this->findTool($toolCall['function']['name'], $tools);
+                while ($messageOutput && isset($messageOutput->tool_calls)) {
+                        $toolMessages = [];
+                        foreach ($messageOutput->tool_calls as $call) {
+                                $tool = $this->findTool($call->function->name, $tools);
                                 if (!$tool) {
                                         continue;
                                 }
-                                $args = json_decode($toolCall['function']['arguments'], true) ?: [];
-                                $output = $tool->run($args);
+                                $args = json_decode($call->function->arguments, true) ?: [];
+                                $result = $tool->run($args);
 
                                 $toolMessages[] = [
                                         'role' => 'tool',
-                                        'tool_call_id' => $toolCall['id'],
-                                        'name' => $toolCall['function']['name'],
-                                        'content' => is_string($output) ? $output : json_encode($output),
+                                        'tool_call_id' => $call->id,
+                                        'name' => $call->function->name,
+                                        'content' => is_string($result) ? $result : json_encode($result),
                                 ];
                         }
 
-                        $messages = array_merge($messages, $toolMessages);
-
-                        $response = $this->client->chat()->create([
-                                'model' => 'gpt-4o',
-                                'messages' => $messages,
+                        $response = $this->client->responses()->create([
+                                'model' => 'gpt-4.1',
+                                'input' => $toolMessages,
+                                'tools' => $toolDefinitions,
+                                'tool_choice' => 'auto',
+                                'previous_response_id' => $response->id,
                         ]);
-                        $message = $response['choices'][0]['message'];
+
+                        $messageOutput = $this->extractMessage($response);
                 }
 
-                // Store the AI response
+                $content = '';
+                $annotations = null;
+                if ($messageOutput && isset($messageOutput->content[0]->text)) {
+                        $content = $messageOutput->content[0]->text;
+                        if (isset($messageOutput->content[0]->annotations) &&
+                                is_array($messageOutput->content[0]->annotations) &&
+                                count($messageOutput->content[0]->annotations) > 0) {
+                                $annotations = $messageOutput->content[0]->annotations;
+                        }
+                }
+
                 $aiChat = $conversation->chats()->create([
                         'role' => 'assistant',
-                        'content' => $message['content'] ?? '',
+                        'content' => $content,
                         'metadata' => [
-                                'model' => 'gpt-4o',
+                                'model' => 'gpt-4.1',
                                 'provider' => 'openai',
+                                'response_id' => $response->id,
                         ],
+                        'annotations' => $annotations,
                 ]);
 
                 return [
@@ -134,6 +148,20 @@ class ChatService
                 foreach ($tools as $tool) {
                         if ($tool->name() === $name) {
                                 return $tool;
+                        }
+                }
+
+                return null;
+        }
+
+        /**
+         * Extract the assistant message from a responses API result.
+         */
+        protected function extractMessage(object $response): ?object
+        {
+                foreach ($response->output as $output) {
+                        if ($output->type === 'message' && $output->role === 'assistant') {
+                                return $output;
                         }
                 }
 

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -4,17 +4,21 @@ namespace App\Services;
 
 use OpenAI\Client;
 use OpenAI;
-use Illuminate\Support\Facades\Log;
 use App\Models\Conversation;
+use App\Tools\ChatTool;
+use App\Tools\ListPromptsTool;
+use App\Tools\GetPromptTool;
+use App\Tools\CreateArticleTool;
+use App\Tools\WriteArticleContentTool;
 
 class ChatService
 {
-	protected Client $client;
+        protected Client $client;
 
-	public function __construct()
-	{
-		$this->client = OpenAI::client(config('services.openai.api_key'));
-	}
+        public function __construct()
+        {
+                $this->client = OpenAI::client(config('services.openai.api_key'));
+        }
 
 	/**
 	 * Generate an AI response for a conversation
@@ -23,113 +27,113 @@ class ChatService
 	 * @param string $userMessage
 	 * @return array
 	 */
-	public function generateResponse(Conversation $conversation, string $userMessage): array
-	{
-		// Store the user message
-		$userChat = $conversation->chats()->create([
-			'role' => 'user',
-			'content' => $userMessage,
-		]);
+        public function generateResponse(Conversation $conversation, string $userMessage): array
+        {
+                // Store the user message
+                $conversation->chats()->create([
+                        'role' => 'user',
+                        'content' => $userMessage,
+                ]);
 
-		// Get AI response
-		$response = $this->getAiResponse($conversation, $userMessage);
+                // Build chat history including system prompt
+                $messages = $conversation->chats()
+                        ->orderBy('created_at')
+                        ->get()
+                        ->map(fn($chat) => [
+                                'role' => $chat->role,
+                                'content' => $chat->content,
+                        ])
+                        ->toArray();
 
-		// Log the response
-		// Log::info('AI Response: ' . json_encode($response));
+                array_unshift($messages, [
+                        'role' => 'system',
+                        'content' => (string) view('prompts.system'),
+                ]);
 
-		// Extract the text content from the response
-		$responseContent = '';
-		$annotations = null;
+                $tools = $this->buildTools($conversation);
+                $toolDefinitions = array_map(fn(ChatTool $t) => $t->definition(), $tools);
 
-		// Find the message output in the response
-		// When web search is used, the message is in the second element of the output array
-		// When web search is not used, the message is in the first element
-		$messageOutput = null;
-		foreach ($response->output as $output) {
-			if ($output->type === 'message' && $output->role === 'assistant') {
-				$messageOutput = $output;
-				break;
-			}
-		}
+                $response = $this->client->chat()->create([
+                        'model' => 'gpt-4o',
+                        'messages' => $messages,
+                        'tools' => $toolDefinitions,
+                        'tool_choice' => 'auto',
+                ]);
 
-		// Extract text content and annotations if message output was found
-		if ($messageOutput && isset($messageOutput->content[0]->text)) {
-			$responseContent = $messageOutput->content[0]->text;
+                $message = $response['choices'][0]['message'];
+                while (isset($message['tool_calls'])) {
+                        $messages[] = $message;
+                        $toolMessages = [];
 
-			// Check if there are any annotations from web search results
-			if (
-				isset($messageOutput->content[0]->annotations) &&
-				is_array($messageOutput->content[0]->annotations) &&
-				count($messageOutput->content[0]->annotations) > 0
-			) {
-				$annotations = $messageOutput->content[0]->annotations;
-			}
-		}
+                        foreach ($message['tool_calls'] as $toolCall) {
+                                $tool = $this->findTool($toolCall['function']['name'], $tools);
+                                if (!$tool) {
+                                        continue;
+                                }
+                                $args = json_decode($toolCall['function']['arguments'], true) ?: [];
+                                $output = $tool->run($args);
 
-		// Store the AI response
-		$aiChat = $conversation->chats()->create([
-			'role' => 'assistant',
-			'content' => $responseContent,
-			'metadata' => [
-				'model' => 'gpt-4.1',
-				'provider' => 'openai',
-				'response_id' => $response->id,
-			],
-			'annotations' => $annotations,
-		]);
+                                $toolMessages[] = [
+                                        'role' => 'tool',
+                                        'tool_call_id' => $toolCall['id'],
+                                        'name' => $toolCall['function']['name'],
+                                        'content' => is_string($output) ? $output : json_encode($output),
+                                ];
+                        }
 
-		return [
-			'id' => $aiChat->id,
-			'role' => $aiChat->role,
-			'content' => $aiChat->content,
-			'created_at' => $aiChat->created_at,
-			'annotations' => $aiChat->annotations,
-		];
-	}
+                        $messages = array_merge($messages, $toolMessages);
 
-	/**
-	 * Get AI response using OpenAI client
-	 *
-	 * @param Conversation $conversation
-	 * @param string $userMessage
-	 * @return object
-	 */
-	private function getAiResponse(Conversation $conversation, string $userMessage): object
-	{
-		// Get the last chat that has a response_id in its metadata (if any)
-		$lastResponseChat = $conversation->chats()
-			->where('role', 'assistant')
-			->whereNotNull('metadata->response_id')
-			->orderBy('created_at', 'desc')
-			->first();
+                        $response = $this->client->chat()->create([
+                                'model' => 'gpt-4o',
+                                'messages' => $messages,
+                        ]);
+                        $message = $response['choices'][0]['message'];
+                }
 
-		$requestData = [
-			'model' => 'gpt-4.1',
-			'input' => $userMessage,
-			// Add web search tool to allow the model to search the web if needed
-			'tools' => [
-				[
-					'type' => 'web_search'
-				]
-			]
-		];
+                // Store the AI response
+                $aiChat = $conversation->chats()->create([
+                        'role' => 'assistant',
+                        'content' => $message['content'] ?? '',
+                        'metadata' => [
+                                'model' => 'gpt-4o',
+                                'provider' => 'openai',
+                        ],
+                ]);
 
-		// If we have a previous response ID, use it to maintain conversation state
-		if ($lastResponseChat && isset($lastResponseChat->metadata['response_id'])) {
-			$requestData['previous_response_id'] = $lastResponseChat->metadata['response_id'];
-		} else {
-			// For new conversations or if no previous response_id exists,
-			// we need to include the system message
-			$systemMessage = (string) view('prompts.system');
-			$requestData['input'] = [
-				['role' => 'system', 'content' => $systemMessage],
-				['role' => 'user', 'content' => $userMessage]
-			];
-		}
+                return [
+                        'id' => $aiChat->id,
+                        'role' => $aiChat->role,
+                        'content' => $aiChat->content,
+                        'created_at' => $aiChat->created_at,
+                ];
+        }
 
-		// Generate AI response using OpenAI Responses API
-		$response = $this->client->responses()->create($requestData);
+        /**
+         * Build the tool instances for this conversation.
+         */
+        protected function buildTools(Conversation $conversation): array
+        {
+                $teamId = $conversation->team_id;
 
-		return $response;
-	}
+                return [
+                        new ListPromptsTool($teamId),
+                        new GetPromptTool($teamId),
+                        new CreateArticleTool($teamId),
+                        new WriteArticleContentTool($teamId),
+                ];
+        }
+
+        /**
+         * Find a tool by name from the provided array.
+         */
+        protected function findTool(string $name, array $tools): ?ChatTool
+        {
+                foreach ($tools as $tool) {
+                        if ($tool->name() === $name) {
+                                return $tool;
+                        }
+                }
+
+                return null;
+        }
 }

--- a/app/Tools/ChatTool.php
+++ b/app/Tools/ChatTool.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Tools;
+
+interface ChatTool
+{
+    /**
+     * Unique name used by the LLM when calling this tool.
+     */
+    public function name(): string;
+
+    /**
+     * Definition array used by OpenAI tool calling.
+     */
+    public function definition(): array;
+
+    /**
+     * Execute the tool with the given arguments.
+     * Should return a string or array that will be sent back to the model.
+     */
+    public function run(array $arguments);
+}

--- a/app/Tools/CreateArticleTool.php
+++ b/app/Tools/CreateArticleTool.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Article;
+
+class CreateArticleTool implements ChatTool
+{
+    public function __construct(protected int $teamId)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'create_article';
+    }
+
+    public function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => $this->name(),
+                'description' => 'Create a new article for the given prompt id.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'prompt_id' => [
+                            'type' => 'integer',
+                            'description' => 'ID of the related prompt',
+                        ],
+                        'title' => [
+                            'type' => 'string',
+                            'description' => 'Optional title for the article',
+                        ],
+                    ],
+                    'required' => ['prompt_id'],
+                ],
+            ],
+        ];
+    }
+
+    public function run(array $arguments)
+    {
+        $promptId = $arguments['prompt_id'] ?? null;
+        if (!$promptId) {
+            return json_encode(['error' => 'prompt_id missing']);
+        }
+
+        $article = Article::create([
+            'team_id' => $this->teamId,
+            'prompt_id' => $promptId,
+            'title' => $arguments['title'] ?? 'Untitled',
+        ]);
+
+        return $article->toJson();
+    }
+}

--- a/app/Tools/GetPromptTool.php
+++ b/app/Tools/GetPromptTool.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Prompt;
+
+class GetPromptTool implements ChatTool
+{
+    public function __construct(protected int $teamId)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'get_prompt';
+    }
+
+    public function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => $this->name(),
+                'description' => 'Fetch a prompt by id for the current team.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'prompt_id' => [
+                            'type' => 'integer',
+                            'description' => 'ID of the prompt to fetch',
+                        ],
+                    ],
+                    'required' => ['prompt_id'],
+                ],
+            ],
+        ];
+    }
+
+    public function run(array $arguments)
+    {
+        $id = $arguments['prompt_id'] ?? null;
+        if (!$id) {
+            return json_encode(['error' => 'prompt_id missing']);
+        }
+
+        $prompt = Prompt::where('team_id', $this->teamId)->find($id);
+        if (!$prompt) {
+            return json_encode(['error' => 'prompt not found']);
+        }
+
+        return $prompt->toJson();
+    }
+}

--- a/app/Tools/ListPromptsTool.php
+++ b/app/Tools/ListPromptsTool.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Prompt;
+
+class ListPromptsTool implements ChatTool
+{
+    public function __construct(protected int $teamId)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'list_prompts';
+    }
+
+    public function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => $this->name(),
+                'description' => 'List recent prompts for the current team. Returns id and content.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => new \stdClass(),
+                ],
+            ],
+        ];
+    }
+
+    public function run(array $arguments)
+    {
+        $prompts = Prompt::where('team_id', $this->teamId)
+            ->orderByDesc('created_at')
+            ->get(['id', 'content']);
+
+        return $prompts->toJson();
+    }
+}

--- a/app/Tools/WriteArticleContentTool.php
+++ b/app/Tools/WriteArticleContentTool.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Article;
+
+class WriteArticleContentTool implements ChatTool
+{
+    public function __construct(protected int $teamId)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'write_article_content';
+    }
+
+    public function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => $this->name(),
+                'description' => 'Write content into an article record.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'article_id' => [
+                            'type' => 'integer',
+                            'description' => 'ID of the article to update',
+                        ],
+                        'content' => [
+                            'type' => 'string',
+                            'description' => 'HTML content for the article',
+                        ],
+                    ],
+                    'required' => ['article_id', 'content'],
+                ],
+            ],
+        ];
+    }
+
+    public function run(array $arguments)
+    {
+        $id = $arguments['article_id'] ?? null;
+        if (!$id) {
+            return json_encode(['error' => 'article_id missing']);
+        }
+        $article = Article::where('team_id', $this->teamId)->find($id);
+        if (!$article) {
+            return json_encode(['error' => 'article not found']);
+        }
+        $article->update([
+            'content' => $arguments['content'] ?? '',
+        ]);
+
+        return $article->toJson();
+    }
+}


### PR DESCRIPTION
## Summary
- enable ChatService tool calling for articles
- define a ChatTool interface with implementations for listing prompts, fetching a prompt, creating articles and writing article content

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68467a5b9478832384e53b661d548432