### PR TITLE
Implement global API error handling with notifications

### DIFF
--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -1,7 +1,10 @@
-<script setup></script>
+<script setup>
+import Notifications from '@/components/Notifications.vue'
+</script>
 
 <template>
-	<div class="min-h-screen bg-neutral-100">
-		<router-view />
-	</div>
+        <div class="min-h-screen bg-neutral-100">
+                <Notifications />
+                <router-view />
+        </div>
 </template>

--- a/resources/js/components/Notifications.vue
+++ b/resources/js/components/Notifications.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="toast-container">
+    <div
+      v-for="notif in notifications"
+      :key="notif.id"
+      class="toast"
+      :class="notif.type"
+    >
+      <span>{{ notif.message }}</span>
+      <button class="close-btn" @click="dismiss(notif.id)">✕</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useNotificationStore } from '@/stores/notificationStore'
+import { storeToRefs } from 'pinia'
+
+const notificationStore = useNotificationStore()
+const { notifications } = storeToRefs(notificationStore)
+
+function dismiss(id) {
+  notificationStore.removeNotification(id)
+}
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  min-width: 250px;
+  margin-bottom: 8px;
+  padding: 12px 16px;
+  border-radius: 4px;
+  color: #fff;
+  font-weight: 500;
+}
+.toast.error { background: #f56565; }
+.toast.success { background: #48bb78; }
+.toast.info { background: #4299e1; }
+.close-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-weight: bold;
+  margin-left: auto;
+  cursor: pointer;
+}
+</style>

--- a/resources/js/components/jobs/JobStatusList.vue
+++ b/resources/js/components/jobs/JobStatusList.vue
@@ -1,8 +1,6 @@
 <template>
 	<div>
-		<div v-if="error" class="bg-red-100 p-3 rounded text-red-700">
-			{{ error }}
-		</div>
+
 
 		<div>
 			<!-- No jobs -->
@@ -122,7 +120,6 @@ const props = defineProps({
 const jobStatusStore = useJobStatusStore()
 const jobs = computed(() => jobStatusStore.jobs)
 const loading = computed(() => jobStatusStore.loading)
-const error = computed(() => jobStatusStore.error)
 
 // Process jobs into batches and non-batched jobs
 const processedBatches = computed(() => {

--- a/resources/js/pages/articles/Create.vue
+++ b/resources/js/pages/articles/Create.vue
@@ -69,10 +69,7 @@ const cancelCreate = () => {
         </div>
       </div>
 
-      <!-- Error state -->
-      <div v-if="articleStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-        {{ articleStore.error }}
-      </div>
+
 
       <div class="flex flex-col gap-6">
         <!-- Title input -->

--- a/resources/js/pages/articles/Edit.vue
+++ b/resources/js/pages/articles/Edit.vue
@@ -246,7 +246,7 @@ const copyContentToClipboard = async () => {
 							<span v-if="articleStore.isSaving" class="flex items-center">
 								<span class="animate-spin h-4 w-4 mr-2 border-t-2 border-b-2 border-neutral-600 rounded-full"></span>
 							</span>
-							<span v-else-if="articleStore.error" class="text-red-600">{{ articleStore.error }}</span>
+                                                        <span v-else class="text-neutral-600"></span>
 						</div>
 
 						<div class="flex gap-2">
@@ -274,10 +274,7 @@ const copyContentToClipboard = async () => {
 					<div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900"></div>
 				</div>
 
-				<!-- Error state -->
-				<div v-else-if="articleStore.error" class="bg-red-100 border border-red-400 text-red-700 pl-4 pr-6 py-3 rounded mb-4">
-					{{ articleStore.error }}
-				</div>
+
 
 				<div v-else class="flex flex-col gap-6">
 					<!-- Versions panel - dynamically loaded -->

--- a/resources/js/pages/articles/Index.vue
+++ b/resources/js/pages/articles/Index.vue
@@ -90,8 +90,8 @@ const deleteArticle = async (id) => {
 			</div>
 
 			<!-- Active jobs message -->
-			<div
-				v-if="!articleStore.error && activeArticleGenerationJobs.length > 0"
+                        <div
+                                v-if="activeArticleGenerationJobs.length > 0"
 				class="p-4 my-4 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2"
 			>
 				<span class="animate-spin h-4 w-4 mr-2 border-t-2 border-b-2 border-green-700 rounded-full"></span>
@@ -103,10 +103,7 @@ const deleteArticle = async (id) => {
 				<div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900"></div>
 			</div>
 
-			<!-- Error state -->
-			<div v-else-if="articleStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-				{{ articleStore.error }}
-			</div>
+
 
 			<!-- No articles -->
 			<div v-else-if="articleStore.articles.length === 0" class="text-center py-16 border border-neutral-200 rounded-xl">

--- a/resources/js/pages/invitations/Index.vue
+++ b/resources/js/pages/invitations/Index.vue
@@ -51,10 +51,7 @@ const declineInvitation = async (teamId) => {
 				<h1 class="text-2xl font-bold">Team Invitations</h1>
 			</div>
 
-			<!-- Error state -->
-			<div v-if="teamStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-				{{ teamStore.error }}
-			</div>
+
 
 			<!-- Success message -->
 			<div v-if="successMessage" class="p-4 mb-4 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2">

--- a/resources/js/pages/organizations/Edit.vue
+++ b/resources/js/pages/organizations/Edit.vue
@@ -174,10 +174,7 @@ const denyRecommendedTerm = async (termId, termName) => {
 				<div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900"></div>
 			</div>
 
-			<!-- Error state -->
-			<div v-else-if="organizationStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-				{{ organizationStore.error }}
-			</div>
+
 
 			<div v-else class="flex flex-col md:flex-row gap-12">
 				<!-- Left column - Terms section -->

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -72,8 +72,8 @@ onMounted(async () => {
 			</div>
 
 			<!-- Active jobs message -->
-			<div
-				v-if="!organizationStore.error && activeCompetitorJobs.length > 0"
+                        <div
+                                v-if="activeCompetitorJobs.length > 0"
 				class="p-4 mt-4 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2"
 			>
 				<span class="animate-spin h-4 w-4 mr-2 border-t-2 border-b-2 border-green-700 rounded-full"></span>
@@ -87,10 +87,7 @@ onMounted(async () => {
 				<div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900"></div>
 			</div>
 
-			<!-- Error state -->
-			<div v-else-if="organizationStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-				{{ organizationStore.error }}
-			</div>
+
 
 			<div v-else>
 				<!-- Your Organization -->

--- a/resources/js/pages/teams/Show.vue
+++ b/resources/js/pages/teams/Show.vue
@@ -115,10 +115,7 @@ const deleteTeam = async () => {
 				<div class="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900"></div>
 			</div>
 
-			<!-- Error state -->
-			<div v-else-if="teamStore.error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-				{{ teamStore.error }}
-			</div>
+
 
 			<div v-else-if="teamStore.currentTeam">
 				<div class="flex justify-between items-center mb-8">

--- a/resources/js/services/api.js
+++ b/resources/js/services/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { useNotificationStore } from '@/stores/notificationStore'
 
 const api = axios.create({
 	baseURL: '/api',
@@ -19,23 +20,51 @@ api.interceptors.request.use((config) => {
 	return config
 })
 
-// Response interceptor for handling errors
+// Response interceptor for handling errors globally
 api.interceptors.response.use(
-	(response) => response.data,
-	(error) => {
-		if (error.response) {
-			// Handle unauthorized errors
-			if (error.response.status === 401) {
-				localStorage.removeItem('token')
-				localStorage.removeItem('user')
-				window.location.href = '/login'
-			}
+        (response) => response.data,
+        (error) => {
+                const notificationStore = useNotificationStore()
 
-			// Return the error response data for better error handling
-			return Promise.reject(error.response.data)
-		}
-		return Promise.reject(error)
-	}
+                if (error.response) {
+                        const status = error.response.status
+
+                        if (status === 401) {
+                                localStorage.removeItem('token')
+                                localStorage.removeItem('user')
+                                window.location.href = '/login'
+                        }
+
+                        let message = 'An error occurred. Please try again.'
+                        const data = error.response.data
+                        if (data) {
+                                if (typeof data === 'string') {
+                                        message = data
+                                } else if (data.message) {
+                                        message = data.message
+                                } else if (data.error) {
+                                        message = data.error
+                                }
+                                if (status === 422 && data.errors) {
+                                        const firstKey = Object.keys(data.errors)[0]
+                                        message = data.errors[firstKey][0] || message
+                                }
+                        }
+
+                        notificationStore.addNotification({
+                                type: 'error',
+                                message
+                        })
+
+                        return Promise.reject(error.response.data)
+                }
+
+                notificationStore.addNotification({
+                        type: 'error',
+                        message: error.message || 'Network error. Please check your connection.'
+                })
+                return Promise.reject(error)
+        }
 )
 
 export default api

--- a/resources/js/stores/articleStore.js
+++ b/resources/js/stores/articleStore.js
@@ -8,8 +8,7 @@ export const useArticleStore = defineStore('article', () => {
 	const article = ref(null)
 	const isLoading = ref(false)
 	const isGenerating = ref(false)
-	const error = ref(null)
-	const isSaving = ref(false)
+        const isSaving = ref(false)
 
 	// Version-related state
 	const articleVersions = ref([])
@@ -21,59 +20,56 @@ export const useArticleStore = defineStore('article', () => {
 	const conversationId = ref(null)
 	const newMessage = ref('')
 
-	const fetchArticles = async () => {
-		isLoading.value = true
-		error.value = null
+        const fetchArticles = async () => {
+                isLoading.value = true
 
 		try {
 			const response = await api.get('/articles')
 			articles.value = response
 			return response
-		} catch (err) {
-			error.value = err.message || 'Failed to fetch articles'
-			throw err
+                } catch (err) {
+                        console.error('Error fetching articles:', err)
+                        throw err
 		} finally {
 			isLoading.value = false
 		}
 	}
 
-	const fetchArticle = async (id) => {
-		isLoading.value = true
-		error.value = null
+        const fetchArticle = async (id) => {
+                isLoading.value = true
 
 		try {
 			const response = await api.get(`/articles/${id}`)
 			article.value = response
 			return response
-		} catch (err) {
-			window.location.href = '/articles'
-			console.error('Error fetching article:', err)
-			throw err
+                } catch (err) {
+                        window.location.href = '/articles'
+                        console.error('Error fetching article:', err)
+                        throw err
 		} finally {
 			isLoading.value = false
 		}
 	}
 
-	const createArticle = async (articleData) => {
-		isLoading.value = true
-		error.value = null
+        const createArticle = async (articleData) => {
+                isLoading.value = true
 
 		try {
 			const response = await api.post('/articles', articleData)
 			await fetchArticles()
 			return response
-		} catch (err) {
-			error.value = err.message || 'Failed to create article'
-			throw err
+                } catch (err) {
+                        console.error('Error creating article:', err)
+                        throw err
 		} finally {
 			isLoading.value = false
 		}
 	}
 
-	const updateArticle = async (id, articleData) => {
-		console.log('Updating article...')
-		isLoading.value = true
-		error.value = null
+        const updateArticle = async (id, articleData) => {
+                console.log('Updating article...')
+                isLoading.value = true
+
 
 		try {
 			const response = await api.put(`/articles/${id}`, articleData)
@@ -84,17 +80,16 @@ export const useArticleStore = defineStore('article', () => {
 			}
 
 			return response
-		} catch (err) {
-			error.value = err.message || 'Failed to update article'
-			throw err
+                } catch (err) {
+                        console.error('Error updating article:', err)
+                        throw err
 		} finally {
 			isLoading.value = false
 		}
 	}
 
-	const deleteArticle = async (id) => {
-		isLoading.value = true
-		error.value = null
+        const deleteArticle = async (id) => {
+                isLoading.value = true
 
 		try {
 			await api.delete(`/articles/${id}`)
@@ -108,9 +103,9 @@ export const useArticleStore = defineStore('article', () => {
 			await fetchArticles()
 
 			return true
-		} catch (err) {
-			error.value = err.message || 'Failed to delete article'
-			throw err
+                } catch (err) {
+                        console.error('Error deleting article:', err)
+                        throw err
 		} finally {
 			isLoading.value = false
 		}
@@ -119,32 +114,30 @@ export const useArticleStore = defineStore('article', () => {
 	/**
 	 * Revert an article to a specific version
 	 */
-	const revertToVersion = async (articleId, versionId) => {
-		error.value = null
+        const revertToVersion = async (articleId, versionId) => {
 
 		try {
 			let response = await api.post(`/articles/${articleId}/versions/${versionId}/revert`)
 			// window.location.reload()
 			article.value = response
-		} catch (err) {
-			error.value = err.message || 'Failed to revert to version'
-			throw err
+                } catch (err) {
+                        console.error('Error reverting article version:', err)
+                        throw err
 		}
 	}
 
 	/**
 	 * Generate an article for a prompt
 	 */
-	const generateArticle = async (promptId) => {
-		isGenerating.value = true
-		error.value = null
+        const generateArticle = async (promptId) => {
+                isGenerating.value = true
 
 		try {
 			const response = await api.post(`/prompts/${promptId}/generate-article`)
 			return response.data
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to generate article'
-			throw err
+                } catch (err) {
+                        console.error('Error generating article:', err)
+                        throw err
 		} finally {
 			isGenerating.value = false
 		}
@@ -164,8 +157,8 @@ export const useArticleStore = defineStore('article', () => {
 			// article.value.versions = response.versions
 			article.value = response
 			console.log('Article auto-saved successfully')
-		} catch (err) {
-			error.value = 'Auto-save failed: ' + (err.message || 'Unknown error')
+                } catch (err) {
+                        console.error('Auto-save failed:', err)
 		} finally {
 			isSaving.value = false
 		}
@@ -315,8 +308,7 @@ export const useArticleStore = defineStore('article', () => {
 		article,
 		isLoading,
 		isGenerating,
-		isSaving,
-		error,
+                isSaving,
 		fetchArticles,
 		fetchArticle,
 		createArticle,

--- a/resources/js/stores/jobStatusStore.js
+++ b/resources/js/stores/jobStatusStore.js
@@ -6,9 +6,8 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 	// State
 	const jobs = ref([])
 	const batch = ref(null)
-	const loading = ref(false)
-	const error = ref(null)
-	let refreshTimer = ref(null)
+        const loading = ref(false)
+        let refreshTimer = ref(null)
 
 	// Getters
 	const activeJobs = computed(() => (jobs.value ? jobs.value.filter((job) => job.status === 'pending' || job.status === 'processing') : []))
@@ -52,15 +51,14 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
         async function fetchTeamJobs() {
                 console.log('Fetching team jobs...')
                 loading.value = true
-                error.value = null
 
 		try {
 			const response = await api.get('/team-jobs')
 			jobs.value = response
 			return jobs.value
-		} catch (err) {
-			error.value = 'Failed to load team jobs: ' + (err.response?.data?.error || err.message)
-			throw err
+                } catch (err) {
+                        console.error('Error loading team jobs:', err)
+                        throw err
 		} finally {
 			loading.value = false
                 }
@@ -71,7 +69,7 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
                         await api.post('/team-jobs/cancel')
                         await fetchTeamJobs()
                 } catch (err) {
-                        error.value = 'Failed to cancel jobs: ' + (err.response?.data?.error || err.message)
+                        console.error('Error cancelling jobs:', err)
                         throw err
                 }
         }
@@ -112,8 +110,7 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		// State
 		jobs: computed(() => jobs.value),
 		batch: computed(() => batch.value),
-		loading,
-		error,
+                loading,
 
 		// Getters
 		activeJobs,

--- a/resources/js/stores/notificationStore.js
+++ b/resources/js/stores/notificationStore.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useNotificationStore = defineStore('notification', () => {
+  const notifications = ref([])
+  let nextId = 1
+
+  function addNotification(notification) {
+    const notif = {
+      id: nextId++,
+      type: notification.type || 'info',
+      message: notification.message
+    }
+    notifications.value.push(notif)
+
+    setTimeout(() => {
+      removeNotification(notif.id)
+    }, 5000)
+  }
+
+  function removeNotification(id) {
+    notifications.value = notifications.value.filter(n => n.id !== id)
+  }
+
+  return {
+    notifications,
+    addNotification,
+    removeNotification
+  }
+})

--- a/resources/js/stores/organizationStore.js
+++ b/resources/js/stores/organizationStore.js
@@ -8,9 +8,8 @@ export const useOrganizationStore = defineStore('organization', () => {
 	const organizations = ref([])
 	const currentOrganization = ref(null)
 	const isLoading = ref(false)
-	const error = ref(null)
-	const visibilityMetrics = ref([])
-	const isLoadingVisibility = ref(false)
+        const visibilityMetrics = ref([])
+        const isLoadingVisibility = ref(false)
 
 	// Other stores
 	const jobStatusStore = useJobStatusStore()
@@ -23,14 +22,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function fetchOrganizations() {
 		console.log('Fetching organizations...')
 		// isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.get('/organizations')
 			organizations.value = response
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to fetch organizations'
-			console.error('Error fetching organizations:', err)
+                } catch (err) {
+                        console.error('Error fetching organizations:', err)
 		} finally {
 			// isLoading.value = false
 		}
@@ -39,15 +37,14 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function fetchOrganization(organizationId) {
 		console.log('Fetching organization details for organization ID:', organizationId)
 		isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.get(`/organizations/${organizationId}`)
 			currentOrganization.value = response
 			return response
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to fetch organization details'
-			console.error('Error fetching organization details:', err)
+                } catch (err) {
+                        console.error('Error fetching organization details:', err)
 		} finally {
 			isLoading.value = false
 		}
@@ -56,15 +53,14 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function createOrganization(organizationData) {
 		console.log('Creating organization...', organizationData)
 		isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.post('/organizations', organizationData)
 			await fetchOrganizations()
 			return response // API interceptor already extracts response.data
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to create organization'
-			console.error('Error creating organization:', err)
+                } catch (err) {
+                        console.error('Error creating organization:', err)
 			throw err
 		} finally {
 			isLoading.value = false
@@ -74,15 +70,14 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function createAndOnboardOrganization(organizationData) {
 		console.log('Creating and onboarding organization...')
 		isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.post('/organizations-onboard', organizationData)
 			await fetchOrganizations()
 			return response // API interceptor already extracts response.data
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to create organization'
-			console.error('Error creating organization:', err)
+                } catch (err) {
+                        console.error('Error creating organization:', err)
 			throw err
 		} finally {
 			isLoading.value = false
@@ -92,7 +87,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function updateOrganization(organizationId, organizationData) {
 		console.log('Updating organization ID:', organizationId)
 		isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.put(`/organizations/${organizationId}`, organizationData)
@@ -104,9 +99,8 @@ export const useOrganizationStore = defineStore('organization', () => {
 			}
 
 			return response
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to update organization'
-			console.error('Error updating organization:', err)
+                } catch (err) {
+                        console.error('Error updating organization:', err)
 			throw err
 		} finally {
 			isLoading.value = false
@@ -116,15 +110,14 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function deleteOrganization(organizationId) {
 		console.log('Deleting organization ID:', organizationId)
 		// isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.delete(`/organizations/${organizationId}`)
 			await fetchOrganizations()
 			return response.data
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to delete organization'
-			console.error('Error deleting organization:', err)
+                } catch (err) {
+                        console.error('Error deleting organization:', err)
 			throw err
 		} finally {
 			// isLoading.value = false
@@ -134,7 +127,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function fetchVisibilityMetrics(params = {}) {
 		console.log('Fetching visibility metrics...')
 		isLoadingVisibility.value = true
-		error.value = null
+
 
 		try {
 			const queryParams = new URLSearchParams()
@@ -147,9 +140,8 @@ export const useOrganizationStore = defineStore('organization', () => {
 			const response = await api.get(url)
 			visibilityMetrics.value = response
 			return response
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to fetch organization visibility metrics'
-			console.error('Error fetching organization visibility metrics:', err)
+                } catch (err) {
+                        console.error('Error fetching organization visibility metrics:', err)
 		} finally {
 			isLoadingVisibility.value = false
 		}
@@ -158,7 +150,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 	async function findCompetitors() {
 		console.log('Finding competitors from past responses...')
 		isLoading.value = true
-		error.value = null
+
 
 		try {
 			const response = await api.post('/organizations-find-competitors')
@@ -166,9 +158,8 @@ export const useOrganizationStore = defineStore('organization', () => {
 			await jobStatusStore.pollTeamJobs()
 
 			return response
-		} catch (err) {
-			error.value = err.response?.data?.message || 'Failed to find competitors. Make sure you have prompt responses.'
-			console.error('Error finding competitors:', err)
+                } catch (err) {
+                        console.error('Error finding competitors:', err)
 			throw err
 		} finally {
 			isLoading.value = false
@@ -180,9 +171,8 @@ export const useOrganizationStore = defineStore('organization', () => {
 		organizations,
 		currentOrganization,
 		isLoading,
-		isLoadingVisibility,
-		error,
-		visibilityMetrics,
+                isLoadingVisibility,
+                visibilityMetrics,
 
 		// Getters
 		ownedOrganizations,

--- a/resources/js/stores/teamStore.js
+++ b/resources/js/stores/teamStore.js
@@ -9,24 +9,21 @@ export const useTeamStore = defineStore('team', {
 		currentTeam: null,
 		members: [],
 		pendingMembers: [],
-		isLoading: false,
-		error: null
+                isLoading: false
 	}),
 
 	actions: {
 		async fetchTeams() {
 			console.log('Fetching teams...')
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.get('/teams')
 				this.ownedTeams = response.ownedTeams
 				this.joinedTeams = response.joinedTeams
 				this.pendingInvitations = response.pendingInvitations
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to fetch teams'
-				console.error('Error fetching teams:', error)
+                        } catch (error) {
+                                console.error('Error fetching teams:', error)
 			} finally {
 				this.isLoading = false
 			}
@@ -34,8 +31,7 @@ export const useTeamStore = defineStore('team', {
 
 		async fetchTeam(teamId) {
 			console.log('Fetching team details for team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.get(`/teams/${teamId}`)
@@ -43,9 +39,8 @@ export const useTeamStore = defineStore('team', {
 				this.members = response.members
 				this.pendingMembers = response.pendingInvitations
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to fetch team details'
-				console.error('Error fetching team details:', error)
+                        } catch (error) {
+                                console.error('Error fetching team details:', error)
 			} finally {
 				this.isLoading = false
 			}
@@ -53,16 +48,14 @@ export const useTeamStore = defineStore('team', {
 
 		async createTeam(teamData) {
 			console.log('Creating team...')
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.post('/teams', teamData)
 				await this.fetchTeams()
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to create team'
-				console.error('Error creating team:', error)
+                        } catch (error) {
+                                console.error('Error creating team:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -71,16 +64,14 @@ export const useTeamStore = defineStore('team', {
 
 		async updateTeam(teamId, teamData) {
 			console.log('Updating team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.put(`/teams/${teamId}`, teamData)
 				await this.fetchTeam(teamId)
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to update team'
-				console.error('Error updating team:', error)
+                        } catch (error) {
+                                console.error('Error updating team:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -89,16 +80,14 @@ export const useTeamStore = defineStore('team', {
 
 		async inviteUser(teamId, userData) {
 			console.log('Inviting user to team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.post(`/teams/${teamId}/invite`, userData)
 				await this.fetchTeam(teamId)
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to invite user'
-				console.error('Error inviting user:', error)
+                        } catch (error) {
+                                console.error('Error inviting user:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -107,17 +96,15 @@ export const useTeamStore = defineStore('team', {
 
 		async acceptInvitation(teamId) {
 			console.log('Accepting invitation for team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.post(`/teams/${teamId}/accept-invitation`)
 				// Remove the accepted invitation from pendingInvitations array
 				this.pendingInvitations = this.pendingInvitations.filter((invitation) => invitation.id !== teamId)
 				await this.switchTeam(teamId)
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to accept invitation'
-				console.error('Error accepting invitation:', error)
+                        } catch (error) {
+                                console.error('Error accepting invitation:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -126,16 +113,14 @@ export const useTeamStore = defineStore('team', {
 
 		async declineInvitation(teamId) {
 			console.log('Declining invitation for team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.post(`/teams/${teamId}/decline-invitation`)
 				await this.fetchTeams()
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to decline invitation'
-				console.error('Error declining invitation:', error)
+                        } catch (error) {
+                                console.error('Error declining invitation:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -144,16 +129,14 @@ export const useTeamStore = defineStore('team', {
 
 		async removeMember(teamId, userId) {
 			console.log('Removing member from team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.delete(`/teams/${teamId}/members/${userId}`)
 				await this.fetchTeam(teamId)
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to remove member'
-				console.error('Error removing member:', error)
+                        } catch (error) {
+                                console.error('Error removing member:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -162,8 +145,7 @@ export const useTeamStore = defineStore('team', {
 
 		async deleteTeam(teamId) {
 			console.log('Deleting team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.delete(`/teams/${teamId}`)
@@ -174,9 +156,8 @@ export const useTeamStore = defineStore('team', {
 					this.pendingMembers = []
 				}
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to delete team'
-				console.error('Error deleting team:', error)
+                        } catch (error) {
+                                console.error('Error deleting team:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -185,16 +166,14 @@ export const useTeamStore = defineStore('team', {
 
 		async updateMemberRole(teamId, userId, roleData) {
 			console.log('Updating member role for team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.put(`/teams/${teamId}/members/${userId}/role`, roleData)
 				await this.fetchTeam(teamId)
 				return response
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to update member role'
-				console.error('Error updating member role:', error)
+                        } catch (error) {
+                                console.error('Error updating member role:', error)
 				throw error
 			} finally {
 				this.isLoading = false
@@ -203,8 +182,7 @@ export const useTeamStore = defineStore('team', {
 
 		async switchTeam(teamId) {
 			console.log('Switching to team ID:', teamId)
-			this.isLoading = true
-			this.error = null
+                        this.isLoading = true
 
 			try {
 				const response = await api.post(`/teams/${teamId}/switch`)
@@ -222,9 +200,8 @@ export const useTeamStore = defineStore('team', {
 					return response
 				}
 				return null
-			} catch (error) {
-				this.error = error.response?.data?.message || 'Failed to switch team'
-				console.error('Error switching team:', error)
+                        } catch (error) {
+                                console.error('Error switching team:', error)
 				throw error
 			} finally {
 				this.isLoading = false


### PR DESCRIPTION
## Summary
- add notification store and toast component
- route all axios errors to the notification store
- remove local error handling from Pinia stores
- clean up pages/components that showed store errors
- show notifications globally in `App.vue`

## Testing
- `npm run build` *(fails: vite not found)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685073613c088323a61353dd3738a99b