### PR TITLE
Add Team global scope

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -12,7 +12,7 @@ use App\Traits\HasVersions;
 
 class Article extends Model
 {
-	use HasFactory, HasJobStatus, HasVersions;
+        use HasFactory, HasJobStatus, HasVersions, \App\Traits\BelongsToTeam;
 
 	protected $fillable = [
 		'team_id',

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -11,7 +11,7 @@ use App\Models\Team;
 
 class Conversation extends Model
 {
-	use HasFactory;
+        use HasFactory, \App\Traits\BelongsToTeam;
 
 	protected $fillable = [
 		'team_id',

--- a/app/Models/JobStatus.php
+++ b/app/Models/JobStatus.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class JobStatus extends Model
 {
-	use Prunable, HasFactory;
+        use Prunable, HasFactory, \App\Traits\BelongsToTeam;
 
 	protected $fillable = [
 		'job_id',

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -11,7 +11,7 @@ use App\Models\Article;
 
 class Organization extends Model
 {
-	use HasFactory, HasJobStatus;
+        use HasFactory, HasJobStatus, \App\Traits\BelongsToTeam;
 
 	protected $guarded = [
 		'id'

--- a/app/Models/Prompt.php
+++ b/app/Models/Prompt.php
@@ -12,7 +12,7 @@ use App\Models\Organization;
 
 class Prompt extends Model
 {
-	use HasFactory, HasJobStatus;
+        use HasFactory, HasJobStatus, \App\Traits\BelongsToTeam;
 
 	protected $fillable = [
 		'team_id',

--- a/app/Models/Term.php
+++ b/app/Models/Term.php
@@ -12,7 +12,7 @@ use App\Traits\HasJobStatus;
 
 class Term extends Model
 {
-	use HasFactory, HasJobStatus;
+        use HasFactory, HasJobStatus, \App\Traits\BelongsToTeam;
 
 	protected $fillable = [
 		'team_id',

--- a/app/Scopes/TeamScope.php
+++ b/app/Scopes/TeamScope.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
+
+class TeamScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $user = Auth::user();
+
+        if ($user && !$user->isSuperAdmin()) {
+            $builder->where($model->getTable() . '.team_id', $user->current_team_id);
+        }
+    }
+}

--- a/app/Traits/BelongsToTeam.php
+++ b/app/Traits/BelongsToTeam.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Traits;
+
+use App\Scopes\TeamScope;
+
+trait BelongsToTeam
+{
+    protected static function bootBelongsToTeam(): void
+    {
+        static::addGlobalScope(new TeamScope());
+    }
+}


### PR DESCRIPTION
## Summary
- add `TeamScope` class to ensure models query by the current team
- create `BelongsToTeam` trait to register the scope
- enable the trait on team-bound models

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_b_6876b6dcc59c83238c86431ba04f912d