### PR TITLE
Use team route binding across controllers

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use App\Models\Team;
 use Illuminate\Http\JsonResponse;
 use App\Services\PerplexityService;
 use App\Models\Organization;
@@ -15,9 +16,9 @@ class ArticleController extends Controller
 	/**
 	 * Display a listing of the resource.
 	 */
-	public function index(): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
+        public function index(Team $team): JsonResponse
+        {
+                $teamId = $team->id;
 
 		$articles = Article::where('team_id', $teamId)
 			->latest()
@@ -29,10 +30,10 @@ class ArticleController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-	public function store(Request $request): JsonResponse
+        public function store(Request $request, Team $team): JsonResponse
 	{
 		// Get the users team id
-		$teamId = $request->user()->currentTeam->id;
+                $teamId = $team->id;
 
 		// Get the owned organization for this team
 		$ownedOrganization = Organization::where('team_id', $teamId)
@@ -49,11 +50,11 @@ class ArticleController extends Controller
 			'content' => 'nullable|string',
 		]);
 
-		$article = request()->user()->currentTeam->articles()->create([
-			...$validated,
-			'team_id' => $teamId,
-			'organization_id' => $ownedOrganization->id,
-		]);
+                $article = $team->articles()->create([
+                        ...$validated,
+                        'team_id' => $teamId,
+                        'organization_id' => $ownedOrganization->id,
+                ]);
 
 		return response()->json($article, 201);
 	}

--- a/app/Http/Controllers/JobStatusController.php
+++ b/app/Http/Controllers/JobStatusController.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\JobStatus;
 use App\Models\Prompt;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
+use App\Models\Team;
 
 class JobStatusController extends Controller
 {
@@ -16,9 +16,9 @@ class JobStatusController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getTeamJobs(Request $request)
+    public function getTeamJobs(Request $request, Team $team)
     {
-        $teamId = Auth::user()->current_team_id;
+        $teamId = $team->id;
 
         // Get job statuses for this team
         $jobStatuses = JobStatus::where('team_id', $teamId)
@@ -32,9 +32,9 @@ class JobStatusController extends Controller
     /**
      * Cancel all pending jobs for the current team.
      */
-    public function cancelTeamJobs(Request $request)
+    public function cancelTeamJobs(Request $request, Team $team)
     {
-        $teamId = Auth::user()->current_team_id;
+        $teamId = $team->id;
 
         $pendingJobs = JobStatus::where('team_id', $teamId)
             ->where('status', 'pending')

--- a/app/Http/Controllers/OrganizationCompetitorController.php
+++ b/app/Http/Controllers/OrganizationCompetitorController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use App\Models\Team;
 use Illuminate\Http\JsonResponse;
 use App\Services\JobDispatcherService;
 use App\Models\Prompt;
@@ -18,12 +19,12 @@ class OrganizationCompetitorController extends Controller
 		$this->jobDispatcher = $jobDispatcher;
 	}
 
-	public function find(Request $request): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
+        public function find(Request $request, Team $team): JsonResponse
+        {
+                $teamId = $team->id;
 
-		// Get all prompts for the current team
-		$prompts = Prompt::where('team_id', $teamId)->get();
+                // Get all prompts for the current team
+                $prompts = Prompt::where('team_id', $teamId)->get();
 
 		if ($prompts->isEmpty()) {
 			return response()->json([

--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use App\Models\Team;
 use Illuminate\Http\JsonResponse;
 use App\Services\JobDispatcherService;
 use App\Models\Organization;
@@ -22,13 +23,11 @@ class OrganizationController extends Controller
 	/**
 	 * Display a listing of the resource.
 	 */
-	public function index(): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
-
-		$organizations = Organization::where('team_id', $teamId)
-			->withCount('terms')
-			->get();
+        public function index(Team $team): JsonResponse
+        {
+                $organizations = Organization::where('team_id', $team->id)
+                        ->withCount('terms')
+                        ->get();
 
 		return response()->json($organizations);
 	}
@@ -36,7 +35,7 @@ class OrganizationController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-	public function store(Request $request): JsonResponse
+        public function store(Request $request, Team $team): JsonResponse
 	{
 		$validated = $request->validate([
 			'name' => 'nullable|string|max:255',
@@ -55,7 +54,7 @@ class OrganizationController extends Controller
 		]);
 
 		// TODO: Move this term creation logic into the organization model boot method
-		$organization = request()->user()->currentTeam->organizations()->create($validated);
+                $organization = $team->organizations()->create($validated);
 
 		// Create a term for the competitor name
 		$nameTerm = Term::create([
@@ -71,9 +70,9 @@ class OrganizationController extends Controller
 			'name' => $organization->website,
 		]);
 
-		foreach ([$nameTerm, $websiteTerm] as $term) {
-			$this->jobDispatcher->dispatch($term, new CheckTermInPastResponsesJob($term, request()->user()->currentTeam->id));
-		}
+                foreach ([$nameTerm, $websiteTerm] as $term) {
+                        $this->jobDispatcher->dispatch($term, new CheckTermInPastResponsesJob($term, $team->id));
+                }
 
 		return response()->json($organization, 201);
 	}

--- a/app/Http/Controllers/OrganizationOnboardController.php
+++ b/app/Http/Controllers/OrganizationOnboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use App\Models\Team;
 use App\Services\JobDispatcherService;
 use App\Models\Term;
 use App\Jobs\GenerateOrganizationKeywords;
@@ -20,7 +21,7 @@ class OrganizationOnboardController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-	public function store(Request $request): JsonResponse
+        public function store(Request $request, Team $team): JsonResponse
 	{
 		$validated = $request->validate([
 			'name' => 'nullable|string|max:255',
@@ -39,7 +40,7 @@ class OrganizationOnboardController extends Controller
 		]);
 
 		// TODO: Move this term creation logic into the organization model boot method
-		$organization = request()->user()->currentTeam->organizations()->create($validated);
+                $organization = $team->organizations()->create($validated);
 
 		// Create a term for the competitor name
 		Term::create([
@@ -56,7 +57,7 @@ class OrganizationOnboardController extends Controller
 		]);
 
 		// Dispatch a job to generate keywords for this organization
-		$this->jobDispatcher->dispatch($organization, new GenerateOrganizationKeywords($organization, $organization->team_id));
+                $this->jobDispatcher->dispatch($organization, new GenerateOrganizationKeywords($organization, $organization->team_id));
 
 		return response()->json($organization, 201);
 	}

--- a/app/Http/Controllers/OrganizationVisibilityChartController.php
+++ b/app/Http/Controllers/OrganizationVisibilityChartController.php
@@ -7,14 +7,15 @@ use App\Models\Response;
 use App\Models\Term;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use App\Models\Team;
 
 class OrganizationVisibilityChartController extends Controller
 {
 	/**
 	 * Get visibility data over time for charting
 	 */
-	public function chartData(Request $request)
-	{
+        public function chartData(Request $request, Team $team)
+        {
 		$request->validate([
 			'start_date' => 'nullable|date',
 			'end_date' => 'nullable|date|after_or_equal:start_date',
@@ -23,7 +24,7 @@ class OrganizationVisibilityChartController extends Controller
 			'organization_ids.*' => 'exists:organizations,id'
 		]);
 
-		$teamId = $request->user()->currentTeam->id;
+                $teamId = $team->id;
 
 		// Handle "all_time" case - if dates are not provided, get the date range from responses
 		if (!$request->start_date || !$request->end_date) {

--- a/app/Http/Controllers/OrganizationVisibilityController.php
+++ b/app/Http/Controllers/OrganizationVisibilityController.php
@@ -7,6 +7,7 @@ use App\Models\Organization;
 use App\Models\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use App\Models\Team;
 
 class OrganizationVisibilityController extends Controller
 {
@@ -14,9 +15,9 @@ class OrganizationVisibilityController extends Controller
 	 * Get visibility metrics for organizations within a date range.
 	 * OPTIMIZED VERSION - Single query approach
 	 */
-	public function index(Request $request)
-	{
-		$teamId = $request->user()->currentTeam->id;
+        public function index(Request $request, Team $team)
+        {
+                $teamId = $team->id;
 
 		// Validate request parameters
 		$request->validate([
@@ -98,9 +99,9 @@ class OrganizationVisibilityController extends Controller
 	 * Alternative implementation using Eloquent with optimized queries
 	 * MODERATE OPTIMIZATION - Better than original but uses Eloquent
 	 */
-	public function indexAlternative(Request $request)
-	{
-		$teamId = $request->user()->currentTeam->id;
+        public function indexAlternative(Request $request, Team $team)
+        {
+                $teamId = $team->id;
 
 		$request->validate([
 			'start_date' => 'nullable|date',
@@ -183,9 +184,9 @@ class OrganizationVisibilityController extends Controller
 	 * Cached version for high-traffic scenarios
 	 * AGGRESSIVE OPTIMIZATION - Adds caching layer
 	 */
-	public function indexCached(Request $request)
-	{
-		$teamId = $request->user()->currentTeam->id;
+        public function indexCached(Request $request, Team $team)
+        {
+                $teamId = $team->id;
 
 		$request->validate([
 			'start_date' => 'nullable|date',

--- a/app/Http/Controllers/TermController.php
+++ b/app/Http/Controllers/TermController.php
@@ -7,7 +7,7 @@ use App\Models\Term;
 use App\Models\Organization;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
+use App\Models\Team;
 use App\Services\JobDispatcherService;
 
 class TermController extends Controller
@@ -19,14 +19,12 @@ class TermController extends Controller
 		$this->jobDispatcher = $jobDispatcher;
 	}
 
-	public function index(Organization $organization, Request $request): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
-
-		// Verify the organization belongs to the user's team
-		if ($organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Organization not found'], 404);
-		}
+        public function index(Team $team, Organization $organization, Request $request): JsonResponse
+        {
+                // Verify the organization belongs to the given team
+                if ($organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Organization not found'], 404);
+                }
 
 		$terms = $organization->terms()
 			->withCount('prompts')
@@ -36,19 +34,17 @@ class TermController extends Controller
 		return response()->json($terms);
 	}
 
-	public function show(Organization $organization, Term $term): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
+        public function show(Team $team, Organization $organization, Term $term): JsonResponse
+        {
+                // Verify the organization belongs to the given team
+                if ($organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Organization not found'], 404);
+                }
 
-		// Verify the organization belongs to the user's team
-		if ($organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Organization not found'], 404);
-		}
-
-		// Check if term belongs to organization owned by user's current team
-		if ($term->organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Not found'], 404);
-		}
+                // Check if term belongs to organization owned by this team
+                if ($term->organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Not found'], 404);
+                }
 
 		// Load term prompts with pivot data
 		$term->load(['prompts' => function ($query) {
@@ -58,43 +54,39 @@ class TermController extends Controller
 		return response()->json($term);
 	}
 
-	public function store(Organization $organization, Request $request): JsonResponse
+        public function store(Team $team, Organization $organization, Request $request): JsonResponse
 	{
 		$validated = $request->validate([
 			'name' => 'required|string',
 		]);
 
-		$teamId = Auth::user()->current_team_id;
+                // Verify the organization belongs to the given team
+                if ($organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Organization not found'], 404);
+                }
 
-		// Verify the organization belongs to the user's team
-		if ($organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Organization not found'], 404);
-		}
+                // Create term with both organization_id and team_id
+                $validated['team_id'] = $team->id;
+                $term = $organization->terms()->create($validated);
 
-		// Create term with both organization_id and team_id
-		$validated['team_id'] = $teamId;
-		$term = $organization->terms()->create($validated);
-
-		// Dispatch a job to check past responses for this term
-		$job = new CheckTermInPastResponsesJob($term, $teamId);
+                // Dispatch a job to check past responses for this term
+                $job = new CheckTermInPastResponsesJob($term, $team->id);
 		$jobStatus = $this->jobDispatcher->dispatch($term, $job);
 
 		return response()->json($term, 201);
 	}
 
-	public function destroy(Organization $organization, Term $term): JsonResponse
-	{
-		$teamId = Auth::user()->current_team_id;
+        public function destroy(Team $team, Organization $organization, Term $term): JsonResponse
+        {
+                // Verify the organization belongs to the given team
+                if ($organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Organization not found'], 404);
+                }
 
-		// Verify the organization belongs to the user's team
-		if ($organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Organization not found'], 404);
-		}
-
-		// Check if term belongs to organization owned by user's current team
-		if ($term->organization->team_id !== $teamId) {
-			return response()->json(['message' => 'Not found'], 404);
-		}
+                // Check if term belongs to organization owned by this team
+                if ($term->organization->team_id !== $team->id) {
+                        return response()->json(['message' => 'Not found'], 404);
+                }
 
 		$term->delete();
 

--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -45,12 +45,12 @@ const logout = async () => {
 }
 
 const switchTeam = async (teamId) => {
-	try {
-		await teamStore.switchTeam(teamId)
-		window.location.href = '/'
-	} catch (error) {
-		console.error('Error switching team:', error)
-	}
+        try {
+                await teamStore.switchTeam(teamId)
+                window.location.href = `/teams/${teamId}`
+        } catch (error) {
+                console.error('Error switching team:', error)
+        }
 }
 
 onMounted(async () => {
@@ -67,7 +67,7 @@ onMounted(async () => {
 			<div class="flex items-center space-x-4">
 				<router-link to="/" class="text-xl font-bold">Paraloom</router-link>
 				<div v-if="isAuthenticated" class="flex items-center space-x-4 ml-6">
-					<router-link to="/" class="text-sm hover:text-neutral-300">Rankings</router-link>
+                                        <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}`" class="text-sm hover:text-neutral-300">Rankings</router-link>
 					<router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/prompts`" class="text-sm hover:text-neutral-300">Prompts</router-link>
                                         <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/organizations`" class="text-sm hover:text-neutral-300">Organizations</router-link>
                                         <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/articles`" class="text-sm hover:text-neutral-300">Articles</router-link>

--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -54,8 +54,10 @@ const switchTeam = async (teamId) => {
 }
 
 onMounted(async () => {
-	jobStatusStore.pollTeamJobs()
-	isTeamDropdownOpen.value = false
+        if (teamStore.currentTeam) {
+                jobStatusStore.pollTeamJobs(teamStore.currentTeam.id)
+        }
+        isTeamDropdownOpen.value = false
 })
 </script>
 
@@ -67,8 +69,8 @@ onMounted(async () => {
 				<div v-if="isAuthenticated" class="flex items-center space-x-4 ml-6">
 					<router-link to="/" class="text-sm hover:text-neutral-300">Rankings</router-link>
 					<router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/prompts`" class="text-sm hover:text-neutral-300">Prompts</router-link>
-					<router-link to="/organizations" class="text-sm hover:text-neutral-300">Organizations</router-link>
-					<router-link to="/articles" class="text-sm hover:text-neutral-300">Articles</router-link>
+                                        <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/organizations`" class="text-sm hover:text-neutral-300">Organizations</router-link>
+                                        <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/articles`" class="text-sm hover:text-neutral-300">Articles</router-link>
 				</div>
 			</div>
 

--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -94,7 +94,7 @@ onMounted(async () => {
 					<router-link v-if="isSuperAdmin" to="/super-admin/organizations" class="text-sm hover:text-neutral-300">Super Admin</router-link>
 
 					<!-- Team settings link -->
-					<router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}`" class="text-sm hover:text-neutral-300"> Team settings </router-link>
+                                        <router-link v-if="currentTeam" :to="`/teams/${currentTeam.id}/members`" class="text-sm hover:text-neutral-300"> Team settings </router-link>
 
 					<!-- Teams dropdown -->
 					<PopoverRoot>

--- a/resources/js/components/organizations/GenerateTermsModal.vue
+++ b/resources/js/components/organizations/GenerateTermsModal.vue
@@ -73,12 +73,13 @@ const handleCreateTerms = () => {
 				{{ error }}
 			</div>
 
-			<TermSuggestions
-				v-if="organization?.website"
-				:domain="organization.website"
-				:organization-id="route.params.id"
-				@create-terms="handleCreateTerms"
-			/>
+                        <TermSuggestions
+                                v-if="organization?.website"
+                                :domain="organization.website"
+                                :organization-id="route.params.id"
+                                :team-id="organization.team_id"
+                                @create-terms="handleCreateTerms"
+                        />
 		</div>
 
 		<!-- <template #footer>

--- a/resources/js/components/prompts/GeneratePromptsModal.vue
+++ b/resources/js/components/prompts/GeneratePromptsModal.vue
@@ -10,6 +10,10 @@ const props = defineProps({
   isOpen: {
     type: Boolean,
     required: true
+  },
+  teamId: {
+    type: [Number, String],
+    required: true
   }
 });
 
@@ -41,7 +45,7 @@ watch(() => props.isOpen, async (isOpen) => {
 
 const fetchOrganizations = async () => {
   try {
-    await organizationStore.fetchOrganizations();
+    await organizationStore.fetchOrganizations(props.teamId);
     organizations.value = organizationStore.organizations;
   } catch (err) {
     console.error('Error fetching organizations:', err);

--- a/resources/js/components/prompts/PromptDetailSheet.vue
+++ b/resources/js/components/prompts/PromptDetailSheet.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, watch, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { usePromptStore } from '@/stores/promptStore'
 import { useArticleStore } from '@/stores/articleStore'
 import api from '@/services/api.js'
@@ -22,6 +22,8 @@ const props = defineProps({
 })
 
 const router = useRouter()
+const route = useRoute()
+const teamId = route.params.teamId
 
 const emit = defineEmits(['close'])
 
@@ -101,10 +103,10 @@ const exportPrompt = async () => {
 }
 
 const createArticle = async () => {
-	const newArticle = await articleStore.createArticle({
-		title: 'Untitled article',
-		prompt_id: props.promptId
-	})
+        const newArticle = await articleStore.createArticle(teamId, {
+                title: 'Untitled article',
+                prompt_id: props.promptId
+        })
 	router.push({ name: 'articles.edit', params: { id: newArticle.id } })
 }
 

--- a/resources/js/components/prompts/PromptListItem.vue
+++ b/resources/js/components/prompts/PromptListItem.vue
@@ -1,7 +1,7 @@
 <script setup>
 import moment from 'moment'
 import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { usePromptStore } from '@/stores/promptStore'
 import { useArticleStore } from '@/stores/articleStore'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
@@ -10,6 +10,8 @@ import TrashIcon from '@/components/icons/TrashIcon.vue'
 import Button from '@/components/ui/Button.vue'
 
 const router = useRouter()
+const route = useRoute()
+const teamId = route.params.teamId
 
 const promptStore = usePromptStore()
 const articleStore = useArticleStore()
@@ -64,10 +66,10 @@ const runPrompt = (count) => {
 const confirmDelete = () => emit('delete', props.prompt)
 
 const createArticle = async () => {
-	const newArticle = await articleStore.createArticle({
-		title: 'Untitled article',
-		prompt_id: props.prompt.id
-	})
+        const newArticle = await articleStore.createArticle(teamId, {
+                title: 'Untitled article',
+                prompt_id: props.prompt.id
+        })
 	router.push({ name: 'articles.edit', params: { id: newArticle.id } })
 }
 </script>

--- a/resources/js/components/prompts/PromptListItem.vue
+++ b/resources/js/components/prompts/PromptListItem.vue
@@ -29,9 +29,9 @@ const isRunMenuOpen = ref(false)
 const isLoading = computed(() => promptStore.loadingPromptIds.includes(props.prompt.id))
 
 const hasActiveRunPromptJob = computed(() => {
-	let jobs = jobStatusStore.jobs.filter(
-		(job) =>
-			job.job_class.includes('RunPromptJob') &&
+        let jobs = (jobStatusStore.jobs || []).filter(
+                (job) =>
+                        job.job_class.includes('RunPromptJob') &&
 			job.trackable_type === 'App\\Models\\Prompt' &&
 			job.trackable_id === props.prompt.id &&
 			(job.status === 'pending' || job.status === 'processing')

--- a/resources/js/components/terms/TermCreateModal.vue
+++ b/resources/js/components/terms/TermCreateModal.vue
@@ -6,10 +6,14 @@ import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const props = defineProps({
-	isOpen: {
-		type: Boolean,
-		required: true
-	}
+        isOpen: {
+                type: Boolean,
+                required: true
+        },
+        teamId: {
+                type: [Number, String],
+                required: true
+        }
 })
 
 const emit = defineEmits(['close', 'create'])
@@ -40,7 +44,7 @@ const addTerm = async () => {
 	if (newTerm.value.trim()) {
 		const termData = { name: newTerm.value.trim() }
 		const processedData = emit('create', termData) || termData
-		await termStore.createTerm(route.params.id, processedData)
+                await termStore.createTerm(props.teamId, route.params.id, processedData)
 		closeModal()
 	}
 }

--- a/resources/js/components/terms/TermSuggestions.vue
+++ b/resources/js/components/terms/TermSuggestions.vue
@@ -9,10 +9,14 @@ const props = defineProps({
 		type: String,
 		required: true
 	},
-	organizationId: {
-		type: String,
-		default: null
-	}
+        organizationId: {
+                type: String,
+                default: null
+        },
+        teamId: {
+                type: [String, Number],
+                required: true
+        }
 })
 
 const emit = defineEmits(['update:terms', 'create-terms'])
@@ -57,10 +61,10 @@ const removeTerm = (index) => {
 }
 
 const createTerms = async () => {
-	if (!generatedTerms.value.length || !props.organizationId) return
+        if (!generatedTerms.value.length || !props.organizationId) return
 
 	try {
-		const promises = generatedTerms.value.map((term) => termStore.createTerm(props.organizationId, { name: term }))
+                const promises = generatedTerms.value.map((term) => termStore.createTerm(props.teamId, props.organizationId, { name: term }))
 
 		await Promise.all(promises)
 		emit('create-terms')

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -17,7 +17,7 @@ const organizationStore = useOrganizationStore()
 
 // Use the store's fetchVisibilityMetrics directly
 const teamId = computed(() => {
-        return route.params.teamId || JSON.parse(localStorage.getItem('user') || '{}').current_team_id
+        return route.params.id || JSON.parse(localStorage.getItem('user') || '{}').current_team_id
 })
 
 const fetchVisibilityData = () => {

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -2,6 +2,7 @@
 import { onMounted, watch, computed } from 'vue'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
 import { useOrganizationStore } from '@/stores/organizationStore'
+import { useTeamStore } from '@/stores/teamStore'
 import VisibilityScore from '@/components/VisibilityScore.vue'
 import VisibilityChart from '@/components/VisibilityChart.vue'
 import DateFilterDropdown from '@/components/DateFilterDropdown.vue'
@@ -10,17 +11,22 @@ import TrashIcon from '../components/icons/TrashIcon.vue'
 
 const jobStatusStore = useJobStatusStore()
 const organizationStore = useOrganizationStore()
+const teamStore = useTeamStore()
 
 // Use centralized state from the store
 
 // Use the store's fetchVisibilityMetrics directly
 const fetchVisibilityData = () => {
-	organizationStore.fetchVisibilityMetrics()
+        if (teamStore.currentTeam) {
+                organizationStore.fetchVisibilityMetrics(teamStore.currentTeam.id)
+        }
 }
 
 // Handle date range changes from dropdown
 const handleDateRangeChange = (dateRange) => {
-	organizationStore.setDateRange(dateRange)
+        if (teamStore.currentTeam) {
+                organizationStore.setDateRange(teamStore.currentTeam.id, dateRange)
+        }
 }
 
 const processingJobsByClass = computed(() => jobStatusStore.processingJobsByClass)

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,31 +1,35 @@
 <script setup>
 import { onMounted, watch, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
 import { useOrganizationStore } from '@/stores/organizationStore'
-import { useTeamStore } from '@/stores/teamStore'
 import VisibilityScore from '@/components/VisibilityScore.vue'
 import VisibilityChart from '@/components/VisibilityChart.vue'
 import DateFilterDropdown from '@/components/DateFilterDropdown.vue'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import TrashIcon from '../components/icons/TrashIcon.vue'
 
+const route = useRoute()
 const jobStatusStore = useJobStatusStore()
 const organizationStore = useOrganizationStore()
-const teamStore = useTeamStore()
 
 // Use centralized state from the store
 
 // Use the store's fetchVisibilityMetrics directly
+const teamId = computed(() => {
+        return route.params.teamId || JSON.parse(localStorage.getItem('user') || '{}').current_team_id
+})
+
 const fetchVisibilityData = () => {
-        if (teamStore.currentTeam) {
-                organizationStore.fetchVisibilityMetrics(teamStore.currentTeam.id)
+        if (teamId.value) {
+                organizationStore.fetchVisibilityMetrics(teamId.value)
         }
 }
 
 // Handle date range changes from dropdown
 const handleDateRangeChange = (dateRange) => {
-        if (teamStore.currentTeam) {
-                organizationStore.setDateRange(teamStore.currentTeam.id, dateRange)
+        if (teamId.value) {
+                organizationStore.setDateRange(teamId.value, dateRange)
         }
 }
 
@@ -55,13 +59,13 @@ onMounted(() => {
 })
 
 const deleteOrganization = async (organizationId) => {
-	try {
-		await organizationStore.deleteOrganization(organizationId)
-		// Refresh visibility data
-		organizationStore.fetchVisibilityMetrics()
-	} catch (error) {
-		console.error('Error deleting organization:', error)
-	}
+        try {
+                await organizationStore.deleteOrganization(teamId.value, organizationId)
+                // Refresh visibility data
+                organizationStore.fetchVisibilityMetrics(teamId.value)
+        } catch (error) {
+                console.error('Error deleting organization:', error)
+        }
 }
 </script>
 

--- a/resources/js/pages/articles/Index.vue
+++ b/resources/js/pages/articles/Index.vue
@@ -31,13 +31,13 @@ const editArticle = (id) => {
 }
 
 const deleteArticle = async (id) => {
-	if (confirm('Are you sure you want to delete this article?')) {
-		try {
-			await articleStore.deleteArticle(id)
-		} catch (error) {
-			console.error('Error deleting article:', error)
-		}
-	}
+        if (confirm('Are you sure you want to delete this article?')) {
+                try {
+                        await articleStore.deleteArticle(teamId, id)
+                } catch (error) {
+                        console.error('Error deleting article:', error)
+                }
+        }
 }
 </script>
 

--- a/resources/js/pages/articles/Index.vue
+++ b/resources/js/pages/articles/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useArticleStore } from '@/stores/articleStore'
 import moment from 'moment'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
@@ -11,16 +11,18 @@ import PlusIcon from '../../components/icons/PlusIcon.vue'
 import DocumentIcon from '../../components/icons/DocumentIcon.vue'
 
 const router = useRouter()
+const route = useRoute()
 const articleStore = useArticleStore()
+const teamId = route.params.teamId
 
 onMounted(async () => {
-	await articleStore.fetchArticles()
+        await articleStore.fetchArticles(teamId)
 })
 
 const createArticle = async () => {
-	const newArticle = await articleStore.createArticle({
-		title: 'Untitled article'
-	})
+        const newArticle = await articleStore.createArticle(teamId, {
+                title: 'Untitled article'
+        })
 	router.push({ name: 'articles.edit', params: { id: newArticle.id } })
 }
 

--- a/resources/js/pages/organizations/Create.vue
+++ b/resources/js/pages/organizations/Create.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useOrganizationStore } from '@/stores/organizationStore'
 import OrganizationLogo from '@/components/organizations/OrganizationLogo.vue'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
@@ -8,7 +8,9 @@ import Button from '@/components/ui/Button.vue'
 import OrganizationSearch from '@/components/OrganizationSearch.vue'
 
 const router = useRouter()
+const route = useRoute()
 const organizationStore = useOrganizationStore()
+const teamId = route.params.teamId
 const isSubmitting = ref(false)
 const isLoadingDetails = ref(false)
 const organization = ref({
@@ -50,9 +52,9 @@ const createOrganization = async () => {
 	isSubmitting.value = true
 	try {
 		// Create the organization
-		const newOrg = await organizationStore.createOrganization(organization.value)
+                const newOrg = await organizationStore.createOrganization(teamId, organization.value)
 
-		router.push({ name: 'organizations.index' })
+        router.push({ name: 'organizations.index', params: { teamId } })
 	} catch (error) {
 		console.error('Error creating organization:', error)
 	} finally {

--- a/resources/js/pages/organizations/Edit.vue
+++ b/resources/js/pages/organizations/Edit.vue
@@ -17,6 +17,7 @@ const route = useRoute()
 const router = useRouter()
 const organizationStore = useOrganizationStore()
 const termStore = useTermStore()
+const teamId = ref(null)
 const organization = ref({
 	name: '',
 	website: '',
@@ -46,10 +47,11 @@ const deletedTermMessage = ref(null)
 
 onMounted(async () => {
 	try {
-		const data = await organizationStore.fetchOrganization(route.params.id)
-		organization.value = { ...data }
-		originalOrganization.value = { ...data }
-		await termStore.fetchTerms(route.params.id)
+                const data = await organizationStore.fetchOrganization(route.params.id)
+                teamId.value = data.team_id
+                organization.value = { ...data }
+                originalOrganization.value = { ...data }
+                await termStore.fetchTerms(teamId.value, route.params.id)
 	} catch (error) {
 		console.error('Error fetching organization:', error)
 	} finally {
@@ -107,7 +109,7 @@ const cancelEdit = () => {
 
 const handleDeleteTerm = (termId, termName) => {
 	deletedTermMessage.value = `The term "${termName}" and its history has been deleted.`
-	termStore.deleteTerm(route.params.id, termId)
+    termStore.deleteTerm(teamId.value, route.params.id, termId)
 	setTimeout(() => {
 		deletedTermMessage.value = null
 	}, 10000)
@@ -206,7 +208,7 @@ const handleDeleteTerm = (termId, termName) => {
 	</DefaultLayout>
 
 	<!-- Term Modal -->
-	<TermCreateModal :is-open="isTermCreateModalOpen" @close="isTermCreateModalOpen = false" @create="addTerm" />
+        <TermCreateModal :is-open="isTermCreateModalOpen" :team-id="teamId" @close="isTermCreateModalOpen = false" @create="addTerm" />
 
 	<!-- Generate Keywords Modal -->
 	<GenerateTermsModal :is-open="isGenerateTermsModalOpen" @close="isGenerateTermsModalOpen = false" />

--- a/resources/js/pages/organizations/Edit.vue
+++ b/resources/js/pages/organizations/Edit.vue
@@ -95,12 +95,12 @@ const updateOrganization = async () => {
 }
 
 const deleteOrganization = async () => {
-	try {
-		await organizationStore.deleteOrganization(route.params.id)
-		router.push({ name: 'organizations.index' })
-	} catch (error) {
-		console.error('Error deleting organization:', error)
-	}
+        try {
+                await organizationStore.deleteOrganization(teamId.value, route.params.id)
+                router.push({ name: 'organizations.index', params: { teamId: teamId.value } })
+        } catch (error) {
+                console.error('Error deleting organization:', error)
+        }
 }
 
 const cancelEdit = () => {

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -2,7 +2,7 @@
 import { onMounted, computed, watch } from 'vue'
 import { useOrganizationStore } from '@/stores/organizationStore'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import moment from 'moment'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import Button from '@/components/ui/Button.vue'
@@ -10,6 +10,8 @@ import Button from '@/components/ui/Button.vue'
 const organizationStore = useOrganizationStore()
 const jobStatusStore = useJobStatusStore()
 const router = useRouter()
+const route = useRoute()
+const teamId = route.params.teamId
 
 // Get active jobs related to competitors
 const activeCompetitorJobs = computed(() => {
@@ -45,8 +47,8 @@ const isNewOrganization = (createdAt) => {
 }
 
 onMounted(async () => {
-	await organizationStore.fetchOrganizations()
-	await jobStatusStore.pollTeamJobs()
+        await organizationStore.fetchOrganizations(teamId)
+        await jobStatusStore.pollTeamJobs(teamId)
 })
 </script>
 
@@ -57,15 +59,15 @@ onMounted(async () => {
 			<div class="flex justify-between items-center mb-3">
 				<h1 class="text-2xl font-bold">Organizations</h1>
 				<div class="flex space-x-2">
-					<Button
-						v-if="organizationStore.ownedOrganizations.length > 0"
-						@click="organizationStore.findCompetitors()"
+                                        <Button
+                                                v-if="organizationStore.ownedOrganizations.length > 0"
+                                                @click="organizationStore.findCompetitors(teamId)"
 						:disabled="activeCompetitorJobs.length > 0"
 						variant="outline"
 					>
 						{{ activeCompetitorJobs.length > 0 ? 'Finding competitors...' : 'Find competitors' }}
 					</Button>
-					<Button @click="router.push({ name: 'organizations.create' })">
+                                        <Button @click="router.push({ name: 'organizations.create', params: { teamId } })">
 						{{ organizationStore.ownedOrganizations.length === 0 ? 'Add your organization' : 'Add competitor' }}
 					</Button>
 				</div>

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -32,10 +32,10 @@ watch(
 				oldJobs.find((oldJob) => oldJob.job_id === job.job_id)?.status !== 'completed'
 		)
 
-		if (completedCompetitorJob) {
-			console.log('Competitor job completed, refreshing organizations')
-			organizationStore.fetchOrganizations()
-		}
+                if (completedCompetitorJob) {
+                        console.log('Competitor job completed, refreshing organizations')
+                        organizationStore.fetchOrganizations(teamId)
+                }
 	},
 	{ deep: true }
 )
@@ -173,10 +173,10 @@ onMounted(async () => {
 								>
 									Edit
 								</router-link>
-								<button
-									@click.stop="organizationStore.deleteOrganization(org.id)"
-									class="text-red-600 hover:text-red-800 text-sm font-medium cursor-pointer"
-								>
+                                                <button
+                                                        @click.stop="organizationStore.deleteOrganization(teamId, org.id)"
+                                                        class="text-red-600 hover:text-red-800 text-sm font-medium cursor-pointer"
+                                                >
 									Remove
 								</button>
 							</div>

--- a/resources/js/pages/prompts/Index.vue
+++ b/resources/js/pages/prompts/Index.vue
@@ -54,14 +54,14 @@ const promptToDelete = ref(null)
 const showDeleteConfirmation = ref(false)
 
 const runPrompt = async (id, count = 1) => {
-	await promptStore.runPrompt(id, count)
-	await jobStatusStore.pollTeamJobs()
+        await promptStore.runPrompt(id, count)
+        await jobStatusStore.pollTeamJobs(teamId.value)
 }
 
 const runAllPrompts = async (count = 1) => {
 	try {
-		await promptStore.runAllPrompts(teamId.value, count)
-		await jobStatusStore.pollTeamJobs()
+                await promptStore.runAllPrompts(teamId.value, count)
+                await jobStatusStore.pollTeamJobs(teamId.value)
 	} catch (error) {
 		console.error('Error running all prompts:', error)
 	}
@@ -120,12 +120,12 @@ const ownedOrg = computed(() => {
 
 // Handle date range changes from dropdown
 const handleDateRangeChange = (dateRange) => {
-	organizationStore.setDateRange(dateRange)
+        organizationStore.setDateRange(teamId.value, dateRange)
 }
 
 onMounted(async () => {
-	await promptStore.fetchPrompts(teamId.value)
-	await organizationStore.fetchVisibilityMetrics()
+        await promptStore.fetchPrompts(teamId.value)
+        await organizationStore.fetchVisibilityMetrics(teamId.value)
 })
 </script>
 

--- a/resources/js/pages/prompts/Index.vue
+++ b/resources/js/pages/prompts/Index.vue
@@ -32,10 +32,10 @@ const sortOption = ref('default') // Default sort option
 // Using centralized date range from organizationStore
 
 const activePromptJobs = computed(() => {
-	const promptJobClasses = ['RunPromptJob', 'FindCompetitorsInResponseJob']
-	return jobStatusStore.jobs.filter((job) => {
-		return promptJobClasses.some((className) => job.job_class.includes(className)) && (job.status === 'pending' || job.status === 'processing')
-	})
+        const promptJobClasses = ['RunPromptJob', 'FindCompetitorsInResponseJob']
+        return (jobStatusStore.jobs || []).filter((job) => {
+                return promptJobClasses.some((className) => job.job_class.includes(className)) && (job.status === 'pending' || job.status === 'processing')
+        })
 })
 
 watch(
@@ -193,7 +193,7 @@ onMounted(async () => {
 	</DefaultLayout>
 
 	<!-- Generate Modal -->
-	<GeneratePromptsModal :is-open="isGenerateModalOpen" @close="isGenerateModalOpen = false" />
+        <GeneratePromptsModal :is-open="isGenerateModalOpen" :team-id="teamId" @close="isGenerateModalOpen = false" />
 
 	<!-- Prompt Modal -->
 	<PromptCreateModal :is-open="isPromptCreateModalOpen" :team-id="teamId" @close="isPromptCreateModalOpen = false" />

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -19,17 +19,24 @@ import ArticleEdit from '@/pages/articles/Edit.vue'
 // Super Admin
 
 const routes = [
-	{
-		path: '/',
-		name: 'home',
-		component: Dashboard,
-		meta: { requiresAuth: true }
-	},
-	{
-		path: '/dashboard',
-		name: 'dashboard',
-		component: Dashboard
-	},
+        {
+                path: '/',
+                redirect: () => {
+                        const user = JSON.parse(localStorage.getItem('user') || '{}')
+                        const teamId = user.current_team_id
+                        return teamId ? `/teams/${teamId}` : '/login'
+                }
+        },
+        {
+                path: '/teams/:teamId?',
+                name: 'home',
+                component: Dashboard,
+                meta: { requiresAuth: true }
+        },
+        {
+                path: '/dashboard',
+                redirect: '/' 
+        },
 	{
 		path: '/login',
 		name: 'login',

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -72,18 +72,26 @@ const routes = [
 		component: TeamCreate,
 		meta: { requiresAuth: true }
 	},
-	{
-		path: '/organizations',
-		name: 'organizations.index',
-		component: OrganizationsIndex,
-		meta: { requiresAuth: true }
-	},
-	{
-		path: '/organizations/create',
-		name: 'organizations.create',
-		component: OrganizationCreate,
-		meta: { requiresAuth: true }
-	},
+        {
+                path: '/organizations',
+                redirect: () => {
+                        const user = JSON.parse(localStorage.getItem('user') || '{}')
+                        const teamId = user.current_team_id
+                        return teamId ? `/teams/${teamId}/organizations` : '/'
+                }
+        },
+        {
+                path: '/teams/:teamId/organizations',
+                name: 'organizations.index',
+                component: OrganizationsIndex,
+                meta: { requiresAuth: true }
+        },
+        {
+                path: '/teams/:teamId/organizations/create',
+                name: 'organizations.create',
+                component: OrganizationCreate,
+                meta: { requiresAuth: true }
+        },
 	{
 		path: '/organizations/:id/edit',
 		name: 'organizations.edit',
@@ -110,12 +118,20 @@ const routes = [
 		component: PromptsIndex,
 		meta: { requiresAuth: true }
 	},
-	{
-		path: '/articles',
-		name: 'articles.index',
-		component: ArticlesIndex,
-		meta: { requiresAuth: true }
-	},
+        {
+                path: '/articles',
+                redirect: () => {
+                        const user = JSON.parse(localStorage.getItem('user') || '{}')
+                        const teamId = user.current_team_id
+                        return teamId ? `/teams/${teamId}/articles` : '/'
+                }
+        },
+        {
+                path: '/teams/:teamId/articles',
+                name: 'articles.index',
+                component: ArticlesIndex,
+                meta: { requiresAuth: true }
+        },
 	{
 		path: '/articles/:id/edit',
 		name: 'articles.edit',

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -28,7 +28,7 @@ const routes = [
                 }
         },
         {
-                path: '/teams/:teamId?',
+                path: '/teams/:id?',
                 name: 'home',
                 component: Dashboard,
                 meta: { requiresAuth: true }
@@ -67,12 +67,12 @@ const routes = [
 		component: InvitationsIndex,
 		meta: { requiresAuth: true }
 	},
-	{
-		path: '/teams/:id',
-		name: 'teams.show',
-		component: TeamShow,
-		meta: { requiresAuth: true }
-	},
+        {
+                path: '/teams/:id/members',
+                name: 'teams.show',
+                component: TeamShow,
+                meta: { requiresAuth: true }
+        },
 	{
 		path: '/teams/create',
 		name: 'teams.create',

--- a/resources/js/stores/articleStore.js
+++ b/resources/js/stores/articleStore.js
@@ -19,12 +19,12 @@ export const useArticleStore = defineStore('article', () => {
 	const conversationId = ref(null)
 	const newMessage = ref('')
 
-	const fetchArticles = async () => {
+        const fetchArticles = async (teamId) => {
 		console.log('Fetching articles...')
 		isLoading.value = true
 
 		try {
-			const response = await api.get('/articles')
+                        const response = await api.get(`/teams/${teamId}/articles`)
 			articles.value = response
 			return response
 		} catch (err) {
@@ -91,13 +91,13 @@ export const useArticleStore = defineStore('article', () => {
 		}
 	}
 
-	const createArticle = async (articleData) => {
+        const createArticle = async (teamId, articleData) => {
 		console.log('Creating article...')
 		isLoading.value = true
 
 		try {
-			const response = await api.post('/articles', articleData)
-			await fetchArticles()
+                        const response = await api.post(`/teams/${teamId}/articles`, articleData)
+                        await fetchArticles(teamId)
 			return response
 		} catch (err) {
 			console.error('Error creating article:', err)
@@ -128,7 +128,7 @@ export const useArticleStore = defineStore('article', () => {
 		}
 	}
 
-	const deleteArticle = async (id) => {
+        const deleteArticle = async (teamId, id) => {
 		console.log('Deleting article...')
 		isLoading.value = true
 
@@ -141,7 +141,7 @@ export const useArticleStore = defineStore('article', () => {
 			}
 
 			// Refresh the articles list
-			await fetchArticles()
+                        await fetchArticles(teamId)
 
 			return true
 		} catch (err) {

--- a/resources/js/stores/jobStatusStore.js
+++ b/resources/js/stores/jobStatusStore.js
@@ -43,17 +43,17 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 	})
 
 	// Actions
-	async function pollTeamJobs() {
-		await fetchTeamJobs()
-		startAutoRefresh(1500)
-	}
+        async function pollTeamJobs(teamId) {
+                await fetchTeamJobs(teamId)
+                startAutoRefresh(1500)
+        }
 
-	async function fetchTeamJobs() {
+        async function fetchTeamJobs(teamId) {
 		console.log('Fetching team jobs...')
 		loading.value = true
 
 		try {
-			const response = await api.get('/team-jobs')
+                        const response = await api.get(`/teams/${teamId}/jobs`)
 			jobs.value = response
 			return jobs.value
 		} catch (err) {
@@ -64,10 +64,10 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		}
 	}
 
-	async function cancelTeamJobs() {
+        async function cancelTeamJobs(teamId) {
 		try {
-			await api.post('/team-jobs/cancel')
-			await fetchTeamJobs()
+                        await api.post(`/teams/${teamId}/jobs/cancel`)
+                        await fetchTeamJobs(teamId)
 		} catch (err) {
 			console.error('Error cancelling jobs:', err)
 			throw err

--- a/resources/js/stores/jobStatusStore.js
+++ b/resources/js/stores/jobStatusStore.js
@@ -45,7 +45,7 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 	// Actions
         async function pollTeamJobs(teamId) {
                 await fetchTeamJobs(teamId)
-                startAutoRefresh(1500)
+                startAutoRefresh(teamId, 1500)
         }
 
         async function fetchTeamJobs(teamId) {
@@ -74,19 +74,19 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		}
 	}
 
-	function hasActiveJobs() {
-		return jobs.value.some((job) => job.status === 'pending' || job.status === 'processing')
-	}
+        function hasActiveJobs() {
+                return Array.isArray(jobs.value) && jobs.value.some((job) => job.status === 'pending' || job.status === 'processing')
+        }
 
-	function startAutoRefresh(interval = 2000) {
-		stopAutoRefresh()
+        function startAutoRefresh(teamId, interval = 2000) {
+                stopAutoRefresh()
 
-		refreshTimer.value = setInterval(() => {
-			if (hasActiveJobs()) {
-				fetchTeamJobs()
-			}
-		}, interval)
-	}
+                refreshTimer.value = setInterval(() => {
+                        if (hasActiveJobs()) {
+                                fetchTeamJobs(teamId)
+                        }
+                }, interval)
+        }
 
 	function stopAutoRefresh() {
 		if (refreshTimer.value) {

--- a/resources/js/stores/organizationStore.js
+++ b/resources/js/stores/organizationStore.js
@@ -26,12 +26,12 @@ export const useOrganizationStore = defineStore('organization', () => {
 	const competitorOrganizations = computed(() => (organizations.value ? organizations.value.filter((org) => org.is_competitor) : []))
 
 	// Actions
-	async function fetchOrganizations() {
-		console.log('Fetching organizations...')
+        async function fetchOrganizations(teamId) {
+                console.log('Fetching organizations...')
 		// isLoading.value = true
 
 		try {
-			const response = await api.get('/organizations')
+                        const response = await api.get(`/teams/${teamId}/organizations`)
 			organizations.value = response
 		} catch (err) {
 			console.error('Error fetching organizations:', err)
@@ -55,12 +55,12 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function createOrganization(organizationData) {
+        async function createOrganization(teamId, organizationData) {
 		console.log('Creating organization...', organizationData)
 		isLoading.value = true
 
 		try {
-			const response = await api.post('/organizations', organizationData)
+                        const response = await api.post(`/teams/${teamId}/organizations`, organizationData)
 			await fetchOrganizations()
 			return response // API interceptor already extracts response.data
 		} catch (err) {
@@ -71,12 +71,12 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function createAndOnboardOrganization(organizationData) {
+        async function createAndOnboardOrganization(teamId, organizationData) {
 		console.log('Creating and onboarding organization...')
 		isLoading.value = true
 
 		try {
-			const response = await api.post('/organizations-onboard', organizationData)
+                        const response = await api.post(`/teams/${teamId}/organizations-onboard`, organizationData)
 			await fetchOrganizations()
 			return response // API interceptor already extracts response.data
 		} catch (err) {
@@ -125,7 +125,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function fetchVisibilityMetrics(params = null) {
+        async function fetchVisibilityMetrics(teamId, params = null) {
 		console.log('Fetching visibility metrics...')
 		isLoadingVisibility.value = true
 
@@ -139,7 +139,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
 			const queryString = queryParams.toString()
 			// const url = `/organization-visibility${queryString ? `?${queryString}` : ''}`
-			const url = `/organization-visibility`
+                        const url = `/teams/${teamId}/organization-visibility`
 
 			const response = await api.get(url)
 			visibilityMetrics.value = response
@@ -151,14 +151,14 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function findCompetitors() {
+        async function findCompetitors(teamId) {
 		console.log('Finding competitors from past responses...')
 		isLoading.value = true
 
 		try {
-			const response = await api.post('/organizations-find-competitors')
+                        const response = await api.post(`/teams/${teamId}/organizations-find-competitors`)
 
-			await jobStatusStore.pollTeamJobs()
+                        await jobStatusStore.pollTeamJobs(teamId)
 
 			return response
 		} catch (err) {
@@ -170,11 +170,11 @@ export const useOrganizationStore = defineStore('organization', () => {
 	}
 
 	// Function to update date range and refresh visibility data
-	function setDateRange(dateRange) {
-		console.log('Setting date range:', dateRange)
-		currentDateRange.value = dateRange
-		return fetchVisibilityMetrics()
-	}
+        function setDateRange(teamId, dateRange) {
+                console.log('Setting date range:', dateRange)
+                currentDateRange.value = dateRange
+                return fetchVisibilityMetrics(teamId)
+        }
 
 	return {
 		// State

--- a/resources/js/stores/organizationStore.js
+++ b/resources/js/stores/organizationStore.js
@@ -61,7 +61,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
 		try {
                         const response = await api.post(`/teams/${teamId}/organizations`, organizationData)
-			await fetchOrganizations()
+                        await fetchOrganizations(teamId)
 			return response // API interceptor already extracts response.data
 		} catch (err) {
 			console.error('Error creating organization:', err)
@@ -77,7 +77,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
 		try {
                         const response = await api.post(`/teams/${teamId}/organizations-onboard`, organizationData)
-			await fetchOrganizations()
+                        await fetchOrganizations(teamId)
 			return response // API interceptor already extracts response.data
 		} catch (err) {
 			console.error('Error creating organization:', err)
@@ -109,13 +109,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function deleteOrganization(organizationId) {
-		console.log('Deleting organization ID:', organizationId)
+        async function deleteOrganization(teamId, organizationId) {
+                console.log('Deleting organization ID:', organizationId)
 		// isLoading.value = true
 
 		try {
-			const response = await api.delete(`/organizations/${organizationId}`)
-			await fetchOrganizations()
+                        const response = await api.delete(`/organizations/${organizationId}`)
+                        await fetchOrganizations(teamId)
 			return response.data
 		} catch (err) {
 			console.error('Error deleting organization:', err)

--- a/resources/js/stores/termStore.js
+++ b/resources/js/stores/termStore.js
@@ -16,12 +16,12 @@ export const useTermStore = defineStore('terms', () => {
 	const jobStatusStore = useJobStatusStore()
 
 	// Actions
-	async function fetchTerms(organizationId) {
+        async function fetchTerms(teamId, organizationId) {
 		console.log('Fetching terms for organization ID:', organizationId)
 		isLoading.value = true
 
 		try {
-			terms.value = await api.get(`organizations/${organizationId}/terms`)
+                        terms.value = await api.get(`teams/${teamId}/organizations/${organizationId}/terms`)
 		} catch (error) {
 			console.error('Error fetching terms:', error)
 		} finally {
@@ -42,11 +42,11 @@ export const useTermStore = defineStore('terms', () => {
 		}
 	}
 
-	async function createTerm(organizationId, data) {
+        async function createTerm(teamId, organizationId, data) {
 		console.log('Creating term for organization ID:', organizationId)
 		isLoading.value = true
 		try {
-			const newTerm = await api.post(`organizations/${organizationId}/terms`, data)
+                        const newTerm = await api.post(`teams/${teamId}/organizations/${organizationId}/terms`, data)
 			terms.value.unshift(newTerm)
 			return newTerm
 		} catch (error) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,23 +46,27 @@ Route::middleware('auth:sanctum')->group(function () {
 
 	Route::post('/logout', [AuthController::class, 'logout']);
 
-	// Organizations
-	Route::resource('organizations', OrganizationController::class);
-	Route::post('organizations-onboard', [OrganizationOnboardController::class, 'store']);
+        // Organizations
+        Route::get('teams/{team}/organizations', [OrganizationController::class, 'index']);
+        Route::post('teams/{team}/organizations', [OrganizationController::class, 'store']);
+        Route::resource('organizations', OrganizationController::class)->except(['index', 'store']);
+        Route::post('teams/{team}/organizations-onboard', [OrganizationOnboardController::class, 'store']);
 
-	// Organization Competitors
-	Route::post('organizations-find-competitors', [OrganizationCompetitorController::class, 'find']);
+        // Organization Competitors
+        Route::post('teams/{team}/organizations-find-competitors', [OrganizationCompetitorController::class, 'find']);
 
-	// Organization Visibility
-	Route::get('organization-visibility', [OrganizationVisibilityController::class, 'index']);
-	Route::get('/organization-visibility/chart', [OrganizationVisibilityChartController::class, 'chartData']);
+        // Organization Visibility
+        Route::get('teams/{team}/organization-visibility', [OrganizationVisibilityController::class, 'index']);
+        Route::get('teams/{team}/organization-visibility/chart', [OrganizationVisibilityChartController::class, 'chartData']);
 
 	// Organization Search
 	Route::get('organization-search', [OrganizationSearchController::class, 'search']);
 	Route::get('brand-details', [OrganizationSearchController::class, 'brandDetails']); // TODO: Maybe remove
 
-	// Terms
-	Route::resource('organizations/{organization}/terms', TermController::class);
+        // Terms
+        Route::get('teams/{team}/organizations/{organization}/terms', [TermController::class, 'index']);
+        Route::post('teams/{team}/organizations/{organization}/terms', [TermController::class, 'store']);
+        Route::resource('organizations/{organization}/terms', TermController::class)->except(['index', 'store']);
 	Route::post('generate-terms', [TermGeneratorController::class, 'generate']);
 	Route::get('terms/{term}/prompts/{prompt}/responses', [TermResponsesController::class, 'index']);
 
@@ -89,13 +93,15 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::delete('teams/{team}/members/{user}', [TeamController::class, 'removeMember']);
 	Route::put('teams/{team}/members/{user}/role', [TeamController::class, 'updateMemberRole']);
 
-	// Job status routes
-	Route::get('/team-jobs', [JobStatusController::class, 'getTeamJobs']);
-	Route::post('/team-jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
+        // Job status routes
+        Route::get('teams/{team}/jobs', [JobStatusController::class, 'getTeamJobs']);
+        Route::post('teams/{team}/jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
 
-	// Articles
-	Route::resource('articles', ArticleController::class);
-	Route::get('articles/{article}/perplexity-response', [ArticleController::class, 'getPerplexityResponse']);
+        // Articles
+        Route::get('teams/{team}/articles', [ArticleController::class, 'index']);
+        Route::post('teams/{team}/articles', [ArticleController::class, 'store']);
+        Route::resource('articles', ArticleController::class)->except(['index', 'store']);
+        Route::get('articles/{article}/perplexity-response', [ArticleController::class, 'getPerplexityResponse']);
 
 	// Article Versions
 	Route::post('articles/{article}/versions/{version}/revert', [ArticleVersionController::class, 'revert']);


### PR DESCRIPTION
## Summary
- bind Team model in various controllers and update API routes
- adjust stores and pages to send teamId in requests
- update frontend navigation for new team-based routes

## Testing
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fd4d76d74832391fc843f8281b8b5