### PR TITLE
Add campaigns for team resources

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\Team;
+use App\Models\Campaign;
 use Illuminate\Http\JsonResponse;
 use App\Services\PerplexityService;
 use App\Models\Organization;
@@ -16,13 +17,14 @@ class ArticleController extends Controller
 	/**
 	 * Display a listing of the resource.
 	 */
-        public function index(Team $team): JsonResponse
+        public function index(Team $team, Campaign $campaign): JsonResponse
         {
                 $teamId = $team->id;
 
-		$articles = Article::where('team_id', $teamId)
-			->latest()
-			->get();
+                $articles = Article::where('team_id', $teamId)
+                        ->where('campaign_id', $campaign->id)
+                        ->latest()
+                        ->get();
 
 		return response()->json($articles);
 	}
@@ -30,7 +32,7 @@ class ArticleController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-        public function store(Request $request, Team $team): JsonResponse
+        public function store(Request $request, Team $team, Campaign $campaign): JsonResponse
 	{
 		// Get the users team id
                 $teamId = $team->id;
@@ -53,6 +55,7 @@ class ArticleController extends Controller
                 $article = $team->articles()->create([
                         ...$validated,
                         'team_id' => $teamId,
+                        'campaign_id' => $campaign->id,
                         'organization_id' => $ownedOrganization->id,
                 ]);
 

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Models\Team;
+use App\Models\Campaign;
+
+class CampaignController extends Controller
+{
+    public function index(Team $team): JsonResponse
+    {
+        return response()->json($team->campaigns()->get());
+    }
+
+    public function store(Request $request, Team $team): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $campaign = $team->campaigns()->create($data);
+
+        return response()->json($campaign, 201);
+    }
+}

--- a/app/Http/Controllers/OrganizationCompetitorController.php
+++ b/app/Http/Controllers/OrganizationCompetitorController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\Team;
+use App\Models\Campaign;
 use Illuminate\Http\JsonResponse;
 use App\Services\JobDispatcherService;
 use App\Models\Prompt;
@@ -19,12 +20,14 @@ class OrganizationCompetitorController extends Controller
 		$this->jobDispatcher = $jobDispatcher;
 	}
 
-        public function find(Request $request, Team $team): JsonResponse
+        public function find(Request $request, Team $team, Campaign $campaign): JsonResponse
         {
                 $teamId = $team->id;
 
                 // Get all prompts for the current team
-                $prompts = Prompt::where('team_id', $teamId)->get();
+                $prompts = Prompt::where('team_id', $teamId)
+                        ->where('campaign_id', $campaign->id)
+                        ->get();
 
 		if ($prompts->isEmpty()) {
 			return response()->json([

--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -23,9 +23,13 @@ class OrganizationController extends Controller
 	/**
 	 * Display a listing of the resource.
 	 */
-        public function index(Team $team): JsonResponse
+        public function index(Team $team, Campaign $campaign): JsonResponse
         {
                 $organizations = Organization::where('team_id', $team->id)
+                        ->where(function ($q) use ($campaign) {
+                                $q->where('campaign_id', $campaign->id)
+                                  ->orWhere('is_competitor', false);
+                        })
                         ->withCount('terms')
                         ->get();
 
@@ -35,8 +39,8 @@ class OrganizationController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-        public function store(Request $request, Team $team): JsonResponse
-	{
+        public function store(Request $request, Team $team, Campaign $campaign): JsonResponse
+        {
 		$validated = $request->validate([
 			'name' => 'nullable|string|max:255',
 			'website' => 'nullable|string|max:255',
@@ -54,7 +58,10 @@ class OrganizationController extends Controller
 		]);
 
 		// TODO: Move this term creation logic into the organization model boot method
-                $organization = $team->organizations()->create($validated);
+                $organization = $team->organizations()->create([
+                        ...$validated,
+                        'campaign_id' => ($validated['is_competitor'] ?? true) ? $campaign->id : null,
+                ]);
 
 		// Create a term for the competitor name
 		$nameTerm = Term::create([

--- a/app/Http/Controllers/OrganizationOnboardController.php
+++ b/app/Http/Controllers/OrganizationOnboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Models\Team;
+use App\Models\Campaign;
 use App\Services\JobDispatcherService;
 use App\Models\Term;
 use App\Jobs\GenerateOrganizationKeywords;
@@ -21,8 +22,8 @@ class OrganizationOnboardController extends Controller
 	/**
 	 * Store a newly created resource in storage.
 	 */
-        public function store(Request $request, Team $team): JsonResponse
-	{
+        public function store(Request $request, Team $team, Campaign $campaign): JsonResponse
+        {
 		$validated = $request->validate([
 			'name' => 'nullable|string|max:255',
 			'website' => 'nullable|string|max:255',
@@ -40,7 +41,10 @@ class OrganizationOnboardController extends Controller
 		]);
 
 		// TODO: Move this term creation logic into the organization model boot method
-                $organization = $team->organizations()->create($validated);
+                $organization = $team->organizations()->create([
+                        ...$validated,
+                        'campaign_id' => ($validated['is_competitor'] ?? true) ? $campaign->id : null,
+                ]);
 
 		// Create a term for the competitor name
 		Term::create([

--- a/app/Http/Controllers/OrganizationVisibilityChartController.php
+++ b/app/Http/Controllers/OrganizationVisibilityChartController.php
@@ -8,13 +8,14 @@ use App\Models\Term;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use App\Models\Team;
+use App\Models\Campaign;
 
 class OrganizationVisibilityChartController extends Controller
 {
 	/**
 	 * Get visibility data over time for charting
 	 */
-        public function chartData(Request $request, Team $team)
+        public function chartData(Request $request, Team $team, Campaign $campaign)
         {
 		$request->validate([
 			'start_date' => 'nullable|date',
@@ -28,13 +29,15 @@ class OrganizationVisibilityChartController extends Controller
 
 		// Handle "all_time" case - if dates are not provided, get the date range from responses
 		if (!$request->start_date || !$request->end_date) {
-			$firstResponse = Response::whereHas('prompt', function ($query) use ($teamId) {
-				$query->where('team_id', $teamId);
-			})->orderBy('created_at')->first();
+                        $firstResponse = Response::whereHas('prompt', function ($query) use ($teamId, $campaign) {
+                                $query->where('team_id', $teamId)
+                                      ->where('campaign_id', $campaign->id);
+                        })->orderBy('created_at')->first();
 
-			$lastResponse = Response::whereHas('prompt', function ($query) use ($teamId) {
-				$query->where('team_id', $teamId);
-			})->orderBy('created_at', 'desc')->first();
+                        $lastResponse = Response::whereHas('prompt', function ($query) use ($teamId, $campaign) {
+                                $query->where('team_id', $teamId)
+                                      ->where('campaign_id', $campaign->id);
+                        })->orderBy('created_at', 'desc')->first();
 
 			if (!$firstResponse || !$lastResponse) {
 				return response()->json([
@@ -56,7 +59,11 @@ class OrganizationVisibilityChartController extends Controller
 		$requestedOrgIds = $request->input('organization_ids', []);
 
 		// Get organizations to track
-		$organizationsQuery = Organization::where('team_id', $teamId);
+                $organizationsQuery = Organization::where('team_id', $teamId)
+                        ->where(function ($q) use ($campaign) {
+                                $q->where('campaign_id', $campaign->id)
+                                  ->orWhere('is_competitor', false);
+                        });
 
 		if (!empty($requestedOrgIds)) {
 			$organizationsQuery->whereIn('id', $requestedOrgIds);
@@ -85,17 +92,19 @@ class OrganizationVisibilityChartController extends Controller
 				$intervalEnd = $intervalData['end'];
 
 				// Calculate visibility for this interval
-				$totalResponses = Response::whereHas('prompt', function ($query) use ($teamId) {
-					$query->where('team_id', $teamId);
-				})
+                                $totalResponses = Response::whereHas('prompt', function ($query) use ($teamId, $campaign) {
+                                        $query->where('team_id', $teamId)
+                                              ->where('campaign_id', $campaign->id);
+                                })
 					->whereBetween('created_at', [$intervalStart, $intervalEnd])
 					->count();
 
 				$totalMentions = 0;
 				if (!empty($termIds) && $totalResponses > 0) {
-					$totalMentions = Response::whereHas('prompt', function ($query) use ($teamId) {
-						$query->where('team_id', $teamId);
-					})
+                                        $totalMentions = Response::whereHas('prompt', function ($query) use ($teamId, $campaign) {
+                                                $query->where('team_id', $teamId)
+                                                      ->where('campaign_id', $campaign->id);
+                                        })
 						->whereHas('terms', function ($query) use ($termIds) {
 							$query->whereIn('terms.id', $termIds);
 						})

--- a/app/Http/Controllers/OrganizationVisibilityController.php
+++ b/app/Http/Controllers/OrganizationVisibilityController.php
@@ -8,6 +8,7 @@ use App\Models\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use App\Models\Team;
+use App\Models\Campaign;
 
 class OrganizationVisibilityController extends Controller
 {
@@ -15,7 +16,7 @@ class OrganizationVisibilityController extends Controller
 	 * Get visibility metrics for organizations within a date range.
 	 * OPTIMIZED VERSION - Single query approach
 	 */
-        public function index(Request $request, Team $team)
+        public function index(Request $request, Team $team, Campaign $campaign)
         {
                 $teamId = $team->id;
 
@@ -29,9 +30,10 @@ class OrganizationVisibilityController extends Controller
 		$endDate = $request->input('end_date');
 
 		// Get total responses count with date filtering
-		$totalResponsesQuery = DB::table('responses')
-			->join('prompts', 'responses.prompt_id', '=', 'prompts.id')
-			->where('prompts.team_id', $teamId);
+                $totalResponsesQuery = DB::table('responses')
+                        ->join('prompts', 'responses.prompt_id', '=', 'prompts.id')
+                        ->where('prompts.team_id', $teamId)
+                        ->where('prompts.campaign_id', $campaign->id);
 
 		if ($startDate) {
 			$totalResponsesQuery->where('responses.created_at', '>=', $startDate);
@@ -56,17 +58,21 @@ class OrganizationVisibilityController extends Controller
                 INNER JOIN term_response tr ON tr.term_id = t.id
                 INNER JOIN responses r ON r.id = tr.response_id
                 INNER JOIN prompts p ON p.id = r.prompt_id
-                WHERE p.team_id = ?
+                WHERE p.team_id = ? AND p.campaign_id = ?
                 ' . ($startDate ? 'AND r.created_at >= ?' : '') . '
                 ' . ($endDate ? 'AND r.created_at <= ?' : '') . '
                 GROUP BY t.organization_id
             ) as mention_data'), 'organizations.id', '=', 'mention_data.organization_id')
-			->where('organizations.team_id', $teamId);
+                        ->where('organizations.team_id', $teamId)
+                        ->where(function ($q) use ($campaign) {
+                                $q->where('organizations.campaign_id', $campaign->id)
+                                  ->orWhere('organizations.is_competitor', false);
+                        });
 
 		// Bind parameters for the subquery
-		$bindings = [$teamId];
-		if ($startDate) $bindings[] = $startDate;
-		if ($endDate) $bindings[] = $endDate;
+                $bindings = [$teamId, $campaign->id];
+                if ($startDate) $bindings[] = $startDate;
+                if ($endDate) $bindings[] = $endDate;
 
 		$organizations = $organizationsWithMentions->addBinding($bindings, 'join')->get();
 
@@ -237,16 +243,20 @@ class OrganizationVisibilityController extends Controller
                 INNER JOIN term_response tr ON tr.term_id = t.id
                 INNER JOIN responses r ON r.id = tr.response_id
                 INNER JOIN prompts p ON p.id = r.prompt_id
-                WHERE p.team_id = ?
+                WHERE p.team_id = ? AND p.campaign_id = ?
                 ' . ($startDate ? 'AND r.created_at >= ?' : '') . '
                 ' . ($endDate ? 'AND r.created_at <= ?' : '') . '
                 GROUP BY t.organization_id
             ) as mention_data'), 'organizations.id', '=', 'mention_data.organization_id')
-			->where('organizations.team_id', $teamId);
+                        ->where('organizations.team_id', $teamId)
+                        ->where(function ($q) use ($campaign) {
+                                $q->where('organizations.campaign_id', $campaign->id)
+                                  ->orWhere('organizations.is_competitor', false);
+                        });
 
-		$bindings = [$teamId];
-		if ($startDate) $bindings[] = $startDate;
-		if ($endDate) $bindings[] = $endDate;
+                $bindings = [$teamId, $campaign->id];
+                if ($startDate) $bindings[] = $startDate;
+                if ($endDate) $bindings[] = $endDate;
 
 		$organizations = $organizationsWithMentions->addBinding($bindings, 'join')->get();
 

--- a/app/Http/Controllers/PromptController.php
+++ b/app/Http/Controllers/PromptController.php
@@ -4,17 +4,19 @@ namespace App\Http\Controllers;
 
 use App\Models\Prompt;
 use App\Models\Team;
+use App\Models\Campaign;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 class PromptController extends Controller
 {
-	public function index(Team $team): JsonResponse
-	{
-		// TODO: Change this if adding projects model
-		$prompts = Prompt::where('team_id', $team->id)
-			->withCount([
+        public function index(Team $team, Campaign $campaign): JsonResponse
+        {
+                // TODO: Change this if adding projects model
+                $prompts = Prompt::where('team_id', $team->id)
+                        ->where('campaign_id', $campaign->id)
+                        ->withCount([
 				// Count terms that are not competitor terms
 				'terms' => function ($query) {
 					$query->whereHas('organization', function ($q) {
@@ -42,8 +44,8 @@ class PromptController extends Controller
 		return response()->json($prompt);
 	}
 
-	public function store(Request $request, Team $team): JsonResponse
-	{
+        public function store(Request $request, Team $team, Campaign $campaign): JsonResponse
+        {
 		$validated = $request->validate([
 			'name' => 'nullable|string',
 			'content' => 'required|string',
@@ -52,7 +54,8 @@ class PromptController extends Controller
 
 		// Add the team_id to the validated data
 		// TODO: Change this if adding projects model
-		$validated['team_id'] = $team->id;
+                $validated['team_id'] = $team->id;
+                $validated['campaign_id'] = $campaign->id;
 
 		$prompt = Prompt::create($validated);
 

--- a/app/Http/Controllers/PromptRunBatchController.php
+++ b/app/Http/Controllers/PromptRunBatchController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Services\JobDispatcherService;
 use App\Models\Team;
+use App\Models\Campaign;
 use App\Models\Prompt;
 use App\Jobs\RunAllPromptsJob;
 
@@ -19,7 +20,7 @@ class PromptRunBatchController extends Controller
 		$this->jobDispatcher = $jobDispatcher;
 	}
 
-	public function store(Request $request, Team $team): JsonResponse
+        public function store(Request $request, Team $team, Campaign $campaign): JsonResponse
 	{
 		$validated = $request->validate([
 			'providers' => 'nullable|array',
@@ -31,7 +32,9 @@ class PromptRunBatchController extends Controller
 		$count = $validated['count'] ?? 1;
 
 		// Get all prompts
-		$prompts = Prompt::where('team_id', $team->id)->get();
+                $prompts = Prompt::where('team_id', $team->id)
+                        ->where('campaign_id', $campaign->id)
+                        ->get();
 
 		if ($prompts->isEmpty()) {
 			return response()->json([

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -60,14 +60,20 @@ class TeamController extends Controller
 	/**
 	 * Store a newly created team in storage.
 	 */
-	public function store(Request $request)
-	{
-		$validated = $request->validate([
-			'name' => ['required', 'string', 'max:255'],
-		]);
+        public function store(Request $request)
+        {
+                $validated = $request->validate([
+                        'name' => ['required', 'string', 'max:255'],
+                ]);
 
 		$validated['owner_id'] = Auth::id();
-		$team = Team::create($validated);
+                $team = Team::create($validated);
+
+                // Create a default campaign for the team
+                $team->campaigns()->create([
+                        'name' => 'Default Campaign',
+                        'is_default' => true,
+                ]);
 
 		// Add the owner as a team member with admin role
 		$team->users()->attach(Auth::id(), [

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -9,15 +9,17 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Traits\HasVersions;
 use App\Traits\HasJobStatus;
 use App\Traits\BelongsToTeam;
+use App\Traits\BelongsToCampaign;
 
 class Article extends Model
 {
-	use HasFactory, HasJobStatus, HasVersions, BelongsToTeam;
+        use HasFactory, HasJobStatus, HasVersions, BelongsToTeam, BelongsToCampaign;
 
-	protected $fillable = [
-		'team_id',
-		'organization_id',
-		'prompt_id',
+        protected $fillable = [
+                'team_id',
+                'campaign_id',
+                'organization_id',
+                'prompt_id',
 		'current_version',
 		'title',
 		'meta_title',

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Campaign extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'name',
+        'is_default',
+    ];
+
+    protected $casts = [
+        'is_default' => 'boolean',
+    ];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function prompts(): HasMany
+    {
+        return $this->hasMany(Prompt::class);
+    }
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(Article::class);
+    }
+
+    public function organizations(): HasMany
+    {
+        return $this->hasMany(Organization::class);
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -8,11 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Traits\HasJobStatus;
 use App\Traits\BelongsToTeam;
+use App\Traits\BelongsToCampaign;
 use App\Models\Article;
 
 class Organization extends Model
 {
-	use HasFactory, HasJobStatus, BelongsToTeam;
+        use HasFactory, HasJobStatus, BelongsToTeam, BelongsToCampaign;
 
 	protected $guarded = [
 		'id'

--- a/app/Models/Prompt.php
+++ b/app/Models/Prompt.php
@@ -9,19 +9,21 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Traits\HasJobStatus;
 use App\Traits\BelongsToTeam;
+use App\Traits\BelongsToCampaign;
 use App\Models\Organization;
 
 class Prompt extends Model
 {
-	use HasFactory, HasJobStatus, BelongsToTeam;
+        use HasFactory, HasJobStatus, BelongsToTeam, BelongsToCampaign;
 
-	protected $fillable = [
-		'team_id',
-		'name',
-		'content',
-		'description',
-		'is_active',
-		'frequency',
+        protected $fillable = [
+                'team_id',
+                'campaign_id',
+                'name',
+                'content',
+                'description',
+                'is_active',
+                'frequency',
 	];
 
 	protected $casts = [

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 use App\Models\JobStatus;
+use App\Models\Campaign;
 
 class Team extends Model
 {
@@ -69,10 +70,18 @@ class Team extends Model
 	/**
 	 * Get the prompts that belong to the team.
 	 */
-	public function prompts(): HasMany
-	{
-		return $this->hasMany(Prompt::class);
-	}
+        public function prompts(): HasMany
+        {
+                return $this->hasMany(Prompt::class);
+        }
+
+        /**
+         * Get the campaigns that belong to the team.
+         */
+        public function campaigns(): HasMany
+        {
+                return $this->hasMany(Campaign::class);
+        }
 
 	/**
 	 * Get the organizations that belong to the team.

--- a/app/Traits/BelongsToCampaign.php
+++ b/app/Traits/BelongsToCampaign.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Campaign;
+
+trait BelongsToCampaign
+{
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+}

--- a/database/migrations/2025_08_01_000000_create_campaigns_table.php
+++ b/database/migrations/2025_08_01_000000_create_campaigns_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('campaigns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campaigns');
+    }
+};

--- a/database/migrations/2025_08_01_010000_add_campaign_id_to_models.php
+++ b/database/migrations/2025_08_01_010000_add_campaign_id_to_models.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->foreignId('campaign_id')->nullable()->after('team_id')->constrained()->cascadeOnDelete();
+        });
+        Schema::table('prompts', function (Blueprint $table) {
+            $table->foreignId('campaign_id')->after('team_id')->constrained()->cascadeOnDelete();
+        });
+        Schema::table('articles', function (Blueprint $table) {
+            $table->foreignId('campaign_id')->after('team_id')->constrained()->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('campaign_id');
+        });
+        Schema::table('prompts', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('campaign_id');
+        });
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('campaign_id');
+        });
+    }
+};

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -24,18 +24,18 @@ const routes = [
                 redirect: () => {
                         const user = JSON.parse(localStorage.getItem('user') || '{}')
                         const teamId = user.current_team_id
-                        return teamId ? `/teams/${teamId}` : '/login'
+                        return teamId ? `/teams/${teamId}/campaigns/1` : '/login'
                 }
         },
         {
-                path: '/teams/:id?',
+                path: '/teams/:teamId/campaigns/:campaignId',
                 name: 'home',
                 component: Dashboard,
                 meta: { requiresAuth: true }
         },
         {
                 path: '/dashboard',
-                redirect: '/' 
+                redirect: '/'
         },
 	{
 		path: '/login',
@@ -112,39 +112,39 @@ const routes = [
 			const user = JSON.parse(localStorage.getItem('user') || '{}')
 			const teamId = user.current_team_id
 
-			if (teamId) {
-				return `/teams/${teamId}/prompts`
-			}
+                        if (teamId) {
+                                return `/teams/${teamId}/campaigns/1/prompts`
+                        }
 			// If no team ID, redirect to home
 			return '/'
 		}
 	},
-	{
-		path: '/teams/:teamId/prompts',
-		name: 'prompts.index',
-		component: PromptsIndex,
-		meta: { requiresAuth: true }
-	},
+        {
+                path: '/teams/:teamId/campaigns/:campaignId/prompts',
+                name: 'prompts.index',
+                component: PromptsIndex,
+                meta: { requiresAuth: true }
+        },
         {
                 path: '/articles',
                 redirect: () => {
                         const user = JSON.parse(localStorage.getItem('user') || '{}')
                         const teamId = user.current_team_id
-                        return teamId ? `/teams/${teamId}/articles` : '/'
+                        return teamId ? `/teams/${teamId}/campaigns/1/articles` : '/'
                 }
         },
         {
-                path: '/teams/:teamId/articles',
+                path: '/teams/:teamId/campaigns/:campaignId/articles',
                 name: 'articles.index',
                 component: ArticlesIndex,
                 meta: { requiresAuth: true }
         },
-	{
-		path: '/articles/:id/edit',
-		name: 'articles.edit',
-		component: ArticleEdit,
-		meta: { requiresAuth: true }
-	},
+        {
+                path: '/teams/:teamId/campaigns/:campaignId/articles/:id/edit',
+                name: 'articles.edit',
+                component: ArticleEdit,
+                meta: { requiresAuth: true }
+        },
 	{
 		path: '/super-admin/organizations',
 		name: 'super-admin.organizations',

--- a/resources/js/stores/articleStore.js
+++ b/resources/js/stores/articleStore.js
@@ -19,12 +19,12 @@ export const useArticleStore = defineStore('article', () => {
 	const conversationId = ref(null)
 	const newMessage = ref('')
 
-        const fetchArticles = async (teamId) => {
+        const fetchArticles = async (teamId, campaignId) => {
 		console.log('Fetching articles...')
 		isLoading.value = true
 
 		try {
-                        const response = await api.get(`/teams/${teamId}/articles`)
+                        const response = await api.get(`/teams/${teamId}/campaigns/${campaignId}/articles`)
 			articles.value = response
 			return response
 		} catch (err) {
@@ -91,13 +91,13 @@ export const useArticleStore = defineStore('article', () => {
 		}
 	}
 
-        const createArticle = async (teamId, articleData) => {
+        const createArticle = async (teamId, campaignId, articleData) => {
 		console.log('Creating article...')
 		isLoading.value = true
 
 		try {
-                        const response = await api.post(`/teams/${teamId}/articles`, articleData)
-                        await fetchArticles(teamId)
+                        const response = await api.post(`/teams/${teamId}/campaigns/${campaignId}/articles`, articleData)
+                        await fetchArticles(teamId, campaignId)
 			return response
 		} catch (err) {
 			console.error('Error creating article:', err)
@@ -128,7 +128,7 @@ export const useArticleStore = defineStore('article', () => {
 		}
 	}
 
-        const deleteArticle = async (teamId, id) => {
+        const deleteArticle = async (teamId, campaignId, id) => {
 		console.log('Deleting article...')
 		isLoading.value = true
 
@@ -141,7 +141,7 @@ export const useArticleStore = defineStore('article', () => {
 			}
 
 			// Refresh the articles list
-                        await fetchArticles(teamId)
+                        await fetchArticles(teamId, campaignId)
 
 			return true
 		} catch (err) {

--- a/resources/js/stores/campaignStore.js
+++ b/resources/js/stores/campaignStore.js
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia'
+import api from '@/services/api'
+
+export const useCampaignStore = defineStore('campaign', {
+    state: () => ({
+        campaigns: [],
+        isLoading: false
+    }),
+    actions: {
+        async fetchCampaigns(teamId) {
+            this.isLoading = true
+            try {
+                this.campaigns = await api.get(`/teams/${teamId}/campaigns`)
+            } finally {
+                this.isLoading = false
+            }
+        },
+        async createCampaign(teamId, data) {
+            this.isLoading = true
+            try {
+                const campaign = await api.post(`/teams/${teamId}/campaigns`, data)
+                this.campaigns.push(campaign)
+                return campaign
+            } finally {
+                this.isLoading = false
+            }
+        }
+    }
+})

--- a/resources/js/stores/organizationStore.js
+++ b/resources/js/stores/organizationStore.js
@@ -26,12 +26,12 @@ export const useOrganizationStore = defineStore('organization', () => {
 	const competitorOrganizations = computed(() => (organizations.value ? organizations.value.filter((org) => org.is_competitor) : []))
 
 	// Actions
-        async function fetchOrganizations(teamId) {
+        async function fetchOrganizations(teamId, campaignId) {
                 console.log('Fetching organizations...')
 		// isLoading.value = true
 
 		try {
-                        const response = await api.get(`/teams/${teamId}/organizations`)
+                        const response = await api.get(`/teams/${teamId}/campaigns/${campaignId}/organizations`)
 			organizations.value = response
 		} catch (err) {
 			console.error('Error fetching organizations:', err)
@@ -55,13 +55,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-        async function createOrganization(teamId, organizationData) {
+        async function createOrganization(teamId, campaignId, organizationData) {
 		console.log('Creating organization...', organizationData)
 		isLoading.value = true
 
 		try {
-                        const response = await api.post(`/teams/${teamId}/organizations`, organizationData)
-                        await fetchOrganizations(teamId)
+                        const response = await api.post(`/teams/${teamId}/campaigns/${campaignId}/organizations`, organizationData)
+                        await fetchOrganizations(teamId, campaignId)
 			return response // API interceptor already extracts response.data
 		} catch (err) {
 			console.error('Error creating organization:', err)
@@ -71,13 +71,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-        async function createAndOnboardOrganization(teamId, organizationData) {
+        async function createAndOnboardOrganization(teamId, campaignId, organizationData) {
 		console.log('Creating and onboarding organization...')
 		isLoading.value = true
 
 		try {
-                        const response = await api.post(`/teams/${teamId}/organizations-onboard`, organizationData)
-                        await fetchOrganizations(teamId)
+                        const response = await api.post(`/teams/${teamId}/campaigns/${campaignId}/organizations-onboard`, organizationData)
+                        await fetchOrganizations(teamId, campaignId)
 			return response // API interceptor already extracts response.data
 		} catch (err) {
 			console.error('Error creating organization:', err)
@@ -109,13 +109,13 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-        async function deleteOrganization(teamId, organizationId) {
+        async function deleteOrganization(teamId, campaignId, organizationId) {
                 console.log('Deleting organization ID:', organizationId)
 		// isLoading.value = true
 
 		try {
                         const response = await api.delete(`/organizations/${organizationId}`)
-                        await fetchOrganizations(teamId)
+                        await fetchOrganizations(teamId, campaignId)
 			return response.data
 		} catch (err) {
 			console.error('Error deleting organization:', err)
@@ -125,7 +125,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-        async function fetchVisibilityMetrics(teamId, params = null) {
+        async function fetchVisibilityMetrics(teamId, campaignId, params = null) {
 		console.log('Fetching visibility metrics...')
 		isLoadingVisibility.value = true
 
@@ -139,7 +139,7 @@ export const useOrganizationStore = defineStore('organization', () => {
 
 			const queryString = queryParams.toString()
 			// const url = `/organization-visibility${queryString ? `?${queryString}` : ''}`
-                        const url = `/teams/${teamId}/organization-visibility`
+                        const url = `/teams/${teamId}/campaigns/${campaignId}/organization-visibility`
 
 			const response = await api.get(url)
 			visibilityMetrics.value = response
@@ -151,12 +151,12 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-        async function findCompetitors(teamId) {
+        async function findCompetitors(teamId, campaignId) {
 		console.log('Finding competitors from past responses...')
 		isLoading.value = true
 
 		try {
-                        const response = await api.post(`/teams/${teamId}/organizations-find-competitors`)
+                        const response = await api.post(`/teams/${teamId}/campaigns/${campaignId}/organizations-find-competitors`)
 
                         await jobStatusStore.pollTeamJobs(teamId)
 
@@ -170,10 +170,10 @@ export const useOrganizationStore = defineStore('organization', () => {
 	}
 
 	// Function to update date range and refresh visibility data
-        function setDateRange(teamId, dateRange) {
+        function setDateRange(teamId, campaignId, dateRange) {
                 console.log('Setting date range:', dateRange)
                 currentDateRange.value = dateRange
-                return fetchVisibilityMetrics(teamId)
+                return fetchVisibilityMetrics(teamId, campaignId)
         }
 
 	return {

--- a/resources/js/stores/promptStore.js
+++ b/resources/js/stores/promptStore.js
@@ -14,12 +14,12 @@ export const usePromptStore = defineStore('prompts', () => {
 	const isRunningAll = ref(false)
 
 	// Actions
-	async function fetchPrompts(teamId) {
+        async function fetchPrompts(teamId, campaignId) {
 		console.log('Fetching prompts...')
 
 		isLoading.value = true
 		try {
-			prompts.value = await api.get(`/teams/${teamId}/prompts`)
+                        prompts.value = await api.get(`/teams/${teamId}/campaigns/${campaignId}/prompts`)
 		} catch (error) {
 			console.error('Error fetching prompts:', error)
 		} finally {
@@ -40,12 +40,12 @@ export const usePromptStore = defineStore('prompts', () => {
 		}
 	}
 
-	async function createPrompt(teamId, data) {
+        async function createPrompt(teamId, campaignId, data) {
 		console.log('Creating prompt...')
 
 		isLoading.value = true
 		try {
-			const newPrompt = await api.post(`/teams/${teamId}/prompts`, data)
+                        const newPrompt = await api.post(`/teams/${teamId}/campaigns/${campaignId}/prompts`, data)
 			prompts.value.unshift(newPrompt)
 			return newPrompt
 		} catch (error) {
@@ -101,12 +101,12 @@ export const usePromptStore = defineStore('prompts', () => {
 		}
 	}
 
-	async function runAllPrompts(teamId, count = 1) {
+        async function runAllPrompts(teamId, campaignId, count = 1) {
 		console.log('Running all prompts...')
 
 		isRunningAll.value = true
 		try {
-			return await api.post(`/teams/${teamId}/prompt-run-batch`, { count })
+                        return await api.post(`/teams/${teamId}/campaigns/${campaignId}/prompt-run-batch`, { count })
 		} catch (error) {
 			console.error('Error running all prompts:', error)
 			throw error

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\SuperAdminOrganizationExportController;
 use App\Http\Controllers\SuperAdminOrganizationController;
 use App\Http\Controllers\PromptRunController;
 use App\Http\Controllers\PromptRunBatchController;
+use App\Http\Controllers\CampaignController;
 use App\Http\Controllers\PromptResponsesController;
 use App\Http\Controllers\PromptGeneratorController;
 use App\Http\Controllers\PromptExportController;
@@ -47,17 +48,17 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::post('/logout', [AuthController::class, 'logout']);
 
         // Organizations
-        Route::get('teams/{team}/organizations', [OrganizationController::class, 'index']);
-        Route::post('teams/{team}/organizations', [OrganizationController::class, 'store']);
+        Route::get('teams/{team}/campaigns/{campaign}/organizations', [OrganizationController::class, 'index']);
+        Route::post('teams/{team}/campaigns/{campaign}/organizations', [OrganizationController::class, 'store']);
         Route::resource('organizations', OrganizationController::class)->except(['index', 'store']);
-        Route::post('teams/{team}/organizations-onboard', [OrganizationOnboardController::class, 'store']);
+        Route::post('teams/{team}/campaigns/{campaign}/organizations-onboard', [OrganizationOnboardController::class, 'store']);
 
         // Organization Competitors
-        Route::post('teams/{team}/organizations-find-competitors', [OrganizationCompetitorController::class, 'find']);
+        Route::post('teams/{team}/campaigns/{campaign}/organizations-find-competitors', [OrganizationCompetitorController::class, 'find']);
 
         // Organization Visibility
-        Route::get('teams/{team}/organization-visibility', [OrganizationVisibilityController::class, 'index']);
-        Route::get('teams/{team}/organization-visibility/chart', [OrganizationVisibilityChartController::class, 'chartData']);
+        Route::get('teams/{team}/campaigns/{campaign}/organization-visibility', [OrganizationVisibilityController::class, 'index']);
+        Route::get('teams/{team}/campaigns/{campaign}/organization-visibility/chart', [OrganizationVisibilityChartController::class, 'chartData']);
 
 	// Organization Search
 	Route::get('organization-search', [OrganizationSearchController::class, 'search']);
@@ -72,8 +73,8 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::get('terms/{term}/prompts/{prompt}/responses', [TermResponsesController::class, 'index']);
 
 	// Prompts
-	Route::get('teams/{team}/prompts', [PromptController::class, 'index']);
-	Route::post('teams/{team}/prompts', [PromptController::class, 'store']);
+        Route::get('teams/{team}/campaigns/{campaign}/prompts', [PromptController::class, 'index']);
+        Route::post('teams/{team}/campaigns/{campaign}/prompts', [PromptController::class, 'store']);
 	Route::get('prompts/{prompt}', [PromptController::class, 'show']);
 	Route::put('prompts/{prompt}', [PromptController::class, 'update']);
 	Route::delete('prompts/{prompt}', [PromptController::class, 'destroy']);
@@ -83,10 +84,14 @@ Route::middleware('auth:sanctum')->group(function () {
 
 	// Running prompts
 	Route::post('prompts/{prompt}/run', [PromptRunController::class, 'store']);
-	Route::post('teams/{team}/prompt-run-batch', [PromptRunBatchController::class, 'store']);
+        Route::post('teams/{team}/campaigns/{campaign}/prompt-run-batch', [PromptRunBatchController::class, 'store']);
 
-	// Team routes
-	Route::resource('teams', TeamController::class);
+        // Campaign routes
+        Route::get('teams/{team}/campaigns', [CampaignController::class, 'index']);
+        Route::post('teams/{team}/campaigns', [CampaignController::class, 'store']);
+
+        // Team routes
+        Route::resource('teams', TeamController::class);
 	Route::post('teams/{team}/invite', [TeamController::class, 'invite']);
 	Route::post('teams/{team}/switch', [TeamController::class, 'switchTeam']);
 	Route::post('teams/{team}/accept-invitation', [TeamController::class, 'acceptInvitation']);
@@ -99,8 +104,8 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('teams/{team}/jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
 
         // Articles
-        Route::get('teams/{team}/articles', [ArticleController::class, 'index']);
-        Route::post('teams/{team}/articles', [ArticleController::class, 'store']);
+        Route::get('teams/{team}/campaigns/{campaign}/articles', [ArticleController::class, 'index']);
+        Route::post('teams/{team}/campaigns/{campaign}/articles', [ArticleController::class, 'store']);
         Route::resource('articles', ArticleController::class)->except(['index', 'store']);
         Route::get('articles/{article}/perplexity-response', [ArticleController::class, 'getPerplexityResponse']);
 


### PR DESCRIPTION
## Summary
- introduce `Campaign` model with migrations
- nest competitors, prompts, and articles under campaigns
- update API routes and controllers for campaign context
- create Pinia store for campaigns and update existing stores
- adjust router to include campaign in dashboard, prompts, and articles paths

## Testing
- `composer test` *(fails: missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68807860a3548323842fba20c66453aa