### PR TITLE
Refactor team onboarding flow

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -4,12 +4,20 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\Campaign;
+use App\Jobs\GenerateCampaignKeywords;
+use App\Services\JobDispatcherService;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 
 class CampaignController extends Controller
 {
+        protected $jobDispatcher;
+
+        public function __construct(JobDispatcherService $jobDispatcher)
+        {
+                $this->jobDispatcher = $jobDispatcher;
+        }
 	/**
 	 * Display a listing of campaigns for a team.
 	 */
@@ -22,20 +30,51 @@ class CampaignController extends Controller
 	/**
 	 * Store a newly created campaign.
 	 */
-	public function store(Request $request, Team $team): JsonResponse
-	{
-		$validated = $request->validate([
-			'name' => 'required|string|max:255',
-			'description' => 'nullable|string',
-			'location' => 'nullable|string|max:255',
-			'keywords' => 'nullable|array',
-			'keywords.*' => 'string|max:255',
-		]);
+        public function store(Request $request, Team $team): JsonResponse
+        {
+                $validated = $request->validate([
+                        'name' => 'required|string|max:255',
+                        'description' => 'nullable|string',
+                        'location' => 'nullable|string|max:255',
+                        'keywords' => 'nullable|array',
+                        'keywords.*' => 'string|max:255',
+                        'is_default' => 'nullable|boolean',
+                ]);
 
-		$campaign = $team->campaigns()->create($validated);
+                $campaign = $team->campaigns()->create($validated);
 
-		return response()->json($campaign, 201);
-	}
+                if ($campaign->is_default && empty($validated['keywords'])) {
+                        $this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
+                }
+
+                return response()->json($campaign, 201);
+        }
+
+        /**
+         * Create a default campaign for a newly created team.
+         */
+        public function createDefault(Request $request, Team $team): JsonResponse
+        {
+                $validated = $request->validate([
+                        'description' => 'nullable|string',
+                        'location' => 'nullable|string|max:255',
+                ]);
+
+                if ($team->campaigns()->where('is_default', true)->exists()) {
+                        return response()->json(['message' => 'Default campaign already exists'], 422);
+                }
+
+                $campaign = $team->campaigns()->create([
+                        'name' => 'Default Campaign',
+                        'is_default' => true,
+                        'description' => $validated['description'] ?? null,
+                        'location' => $validated['location'] ?? null,
+                ]);
+
+                $this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
+
+                return response()->json($campaign, 201);
+        }
 
 	/**
 	 * Display the specified campaign.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -12,12 +12,12 @@ use Illuminate\Support\Facades\DB;
 
 class CampaignController extends Controller
 {
-        protected $jobDispatcher;
+	protected $jobDispatcher;
 
-        public function __construct(JobDispatcherService $jobDispatcher)
-        {
-                $this->jobDispatcher = $jobDispatcher;
-        }
+	public function __construct(JobDispatcherService $jobDispatcher)
+	{
+		$this->jobDispatcher = $jobDispatcher;
+	}
 	/**
 	 * Display a listing of campaigns for a team.
 	 */
@@ -30,51 +30,47 @@ class CampaignController extends Controller
 	/**
 	 * Store a newly created campaign.
 	 */
-        public function store(Request $request, Team $team): JsonResponse
-        {
-                $validated = $request->validate([
-                        'name' => 'required|string|max:255',
-                        'description' => 'nullable|string',
-                        'location' => 'nullable|string|max:255',
-                        'keywords' => 'nullable|array',
-                        'keywords.*' => 'string|max:255',
-                        'is_default' => 'nullable|boolean',
-                ]);
+	public function store(Request $request, Team $team): JsonResponse
+	{
+		$validated = $request->validate([
+			'name' => 'required|string|max:255',
+			'description' => 'nullable|string',
+			'location' => 'nullable|string|max:255',
+			'is_default' => 'nullable|boolean',
+		]);
 
-                $campaign = $team->campaigns()->create($validated);
+		$campaign = $team->campaigns()->create($validated);
 
-                if ($campaign->is_default && empty($validated['keywords'])) {
-                        $this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
-                }
+		$this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
 
-                return response()->json($campaign, 201);
-        }
+		return response()->json($campaign, 201);
+	}
 
-        /**
-         * Create a default campaign for a newly created team.
-         */
-        public function createDefault(Request $request, Team $team): JsonResponse
-        {
-                $validated = $request->validate([
-                        'description' => 'nullable|string',
-                        'location' => 'nullable|string|max:255',
-                ]);
+	/**
+	 * Create a default campaign for a newly created team.
+	 */
+	public function createDefault(Request $request, Team $team): JsonResponse
+	{
+		$validated = $request->validate([
+			'description' => 'nullable|string',
+			'location' => 'nullable|string|max:255',
+		]);
 
-                if ($team->campaigns()->where('is_default', true)->exists()) {
-                        return response()->json(['message' => 'Default campaign already exists'], 422);
-                }
+		if ($team->campaigns()->where('is_default', true)->exists()) {
+			return response()->json(['message' => 'Default campaign already exists'], 422);
+		}
 
-                $campaign = $team->campaigns()->create([
-                        'name' => 'Default Campaign',
-                        'is_default' => true,
-                        'description' => $validated['description'] ?? null,
-                        'location' => $validated['location'] ?? null,
-                ]);
+		$campaign = $team->campaigns()->create([
+			'name' => 'Default Campaign',
+			'is_default' => true,
+			'description' => $validated['description'] ?? null,
+			'location' => $validated['location'] ?? null,
+		]);
 
-                $this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
+		$this->jobDispatcher->dispatch($campaign, new GenerateCampaignKeywords($campaign));
 
-                return response()->json($campaign, 201);
-        }
+		return response()->json($campaign, 201);
+	}
 
 	/**
 	 * Display the specified campaign.

--- a/app/Http/Controllers/OrganizationCompetitorController.php
+++ b/app/Http/Controllers/OrganizationCompetitorController.php
@@ -19,12 +19,12 @@ class OrganizationCompetitorController extends Controller
 		$this->jobDispatcher = $jobDispatcher;
 	}
 
-        public function find(Request $request, Team $team): JsonResponse
-        {
-                $teamId = $team->id;
+	public function find(Request $request, Team $team): JsonResponse
+	{
+		$teamId = $team->id;
 
-                // Get all prompts for the current team
-                $prompts = Prompt::where('team_id', $teamId)->get();
+		// Get all prompts for the current team
+		$prompts = Prompt::where('team_id', $teamId)->get();
 
 		if ($prompts->isEmpty()) {
 			return response()->json([

--- a/app/Http/Controllers/OrganizationOnboardController.php
+++ b/app/Http/Controllers/OrganizationOnboardController.php
@@ -4,20 +4,11 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use App\Services\JobDispatcherService;
 use App\Models\Term;
 use App\Models\Team;
-use App\Models\Campaign;
-use App\Jobs\GenerateCampaignKeywords;
 
 class OrganizationOnboardController extends Controller
 {
-	protected $jobDispatcher;
-
-	public function __construct(JobDispatcherService $jobDispatcher)
-	{
-		$this->jobDispatcher = $jobDispatcher;
-	}
 
 	/**
 	 * Store a newly created resource in storage.
@@ -40,25 +31,8 @@ class OrganizationOnboardController extends Controller
 			'is_competitor' => 'boolean',
 		]);
 
-		// Extract campaign fields
-		$campaignFields = [
-			'location' => $validated['location'] ?? null,
-			'description' => $validated['description'] ?? null,
-		];
-
-		// Remove campaign fields from organization data
-		unset($validated['location'], $validated['description']);
-
-		// Create the team's own organization
-		$organization = $team->organizations()->create($validated);
-
-		// Create default campaign if it doesn't exist
-		$campaign = Campaign::create([
-			'team_id' => $team->id,
-			'name' => 'Default Campaign',
-			'is_default' => true,
-			...$campaignFields
-		]);
+                // Create the team's own organization
+                $organization = $team->organizations()->create($validated);
 
 		// Create a term for the organization's name
 		Term::create([
@@ -74,9 +48,6 @@ class OrganizationOnboardController extends Controller
 			'name' => $organization->website,
 		]);
 
-		// Dispatch a job to generate keywords for the campaign
-		$this->jobDispatcher->dispatch($organization, new GenerateCampaignKeywords($campaign, $organization, $organization->team_id));
-
-		return response()->json($organization, 201);
-	}
+                return response()->json($organization, 201);
+        }
 }

--- a/app/Http/Controllers/OrganizationOnboardController.php
+++ b/app/Http/Controllers/OrganizationOnboardController.php
@@ -31,8 +31,8 @@ class OrganizationOnboardController extends Controller
 			'is_competitor' => 'boolean',
 		]);
 
-                // Create the team's own organization
-                $organization = $team->organizations()->create($validated);
+		// Create the team's own organization
+		$organization = $team->organizations()->create($validated);
 
 		// Create a term for the organization's name
 		Term::create([
@@ -48,6 +48,6 @@ class OrganizationOnboardController extends Controller
 			'name' => $organization->website,
 		]);
 
-                return response()->json($organization, 201);
-        }
+		return response()->json($organization, 201);
+	}
 }

--- a/app/Jobs/GenerateCampaignKeywords.php
+++ b/app/Jobs/GenerateCampaignKeywords.php
@@ -35,25 +35,24 @@ class GenerateCampaignKeywords extends TrackableJob
 	 */
 	public $campaign;
 
-	/**
-	 * The organization used to generate keywords.
-	 *
-	 * @var Organization
-	 */
-	public $organization;
+        /**
+         * The organization used to generate keywords.
+         *
+         * @var Organization|null
+         */
+        protected $organization;
 
 	/**
 	 * Create a new job instance.
 	 *
-	 * @param \App\Models\Campaign $campaign
-	 * @param  \App\Models\Prompt  $prompt
-	 * @return void
-	 */
-	public function __construct(Campaign $campaign, Organization $organization)
-	{
-		$this->campaign = $campaign;
-		$this->organization = $organization;
-	}
+         * @param \App\Models\Campaign $campaign
+         * @return void
+         */
+        public function __construct(Campaign $campaign)
+        {
+                $this->campaign = $campaign;
+                $this->model = $campaign;
+        }
 
 	/**
 	 * Execute the job.
@@ -63,13 +62,22 @@ class GenerateCampaignKeywords extends TrackableJob
 	 */
 	public function handle(JobDispatcherService $jobDispatcher)
 	{
-		try {
-			if ($this->isCancelled()) {
-				return;
-			}
+                try {
+                        if ($this->isCancelled()) {
+                                return;
+                        }
 
-			// Mark the job as started
-			$this->markJobAsStarted('Finding keywords for ' . $this->organization->name);
+                        $this->organization = Organization::where('team_id', $this->campaign->team_id)
+                                ->where('is_competitor', false)
+                                ->first();
+
+                        if (!$this->organization) {
+                                $this->markJobAsCompleted('No owned organization found for team');
+                                return;
+                        }
+
+                        // Mark the job as started
+                        $this->markJobAsStarted('Finding keywords for ' . $this->organization->name);
 
 			// Create a search API tool
 			$searchApiTool = new SearchApiTool();

--- a/app/Jobs/GenerateCampaignKeywords.php
+++ b/app/Jobs/GenerateCampaignKeywords.php
@@ -35,24 +35,23 @@ class GenerateCampaignKeywords extends TrackableJob
 	 */
 	public $campaign;
 
-        /**
-         * The organization used to generate keywords.
-         *
-         * @var Organization|null
-         */
-        protected $organization;
+	/**
+	 * The organization used to generate keywords.
+	 *
+	 * @var Organization|null
+	 */
+	protected $organization;
 
 	/**
 	 * Create a new job instance.
 	 *
-         * @param \App\Models\Campaign $campaign
-         * @return void
-         */
-        public function __construct(Campaign $campaign)
-        {
-                $this->campaign = $campaign;
-                $this->model = $campaign;
-        }
+	 * @param \App\Models\Campaign $campaign
+	 * @return void
+	 */
+	public function __construct(Campaign $campaign)
+	{
+		$this->campaign = $campaign;
+	}
 
 	/**
 	 * Execute the job.
@@ -62,22 +61,22 @@ class GenerateCampaignKeywords extends TrackableJob
 	 */
 	public function handle(JobDispatcherService $jobDispatcher)
 	{
-                try {
-                        if ($this->isCancelled()) {
-                                return;
-                        }
+		try {
+			if ($this->isCancelled()) {
+				return;
+			}
 
-                        $this->organization = Organization::where('team_id', $this->campaign->team_id)
-                                ->where('is_competitor', false)
-                                ->first();
+			$this->organization = Organization::where('team_id', $this->campaign->team_id)
+				->where('is_competitor', false)
+				->first();
 
-                        if (!$this->organization) {
-                                $this->markJobAsCompleted('No owned organization found for team');
-                                return;
-                        }
+			if (!$this->organization) {
+				$this->markJobAsCompleted('No owned organization found for team');
+				return;
+			}
 
-                        // Mark the job as started
-                        $this->markJobAsStarted('Finding keywords for ' . $this->organization->name);
+			// Mark the job as started
+			$this->markJobAsStarted('Finding keywords for ' . $this->organization->name);
 
 			// Create a search API tool
 			$searchApiTool = new SearchApiTool();

--- a/app/Jobs/GeneratePrompt.php
+++ b/app/Jobs/GeneratePrompt.php
@@ -55,13 +55,12 @@ class GeneratePrompt extends TrackableJob
 	 * @param  string  $keyword
 	 * @return void
 	 */
-        public function __construct(Campaign $campaign, Organization $organization, string $keyword)
-        {
-                $this->campaign = $campaign;
-                $this->organization = $organization;
-                $this->keyword = $keyword;
-                $this->model = $campaign;
-        }
+	public function __construct(Campaign $campaign, Organization $organization, string $keyword)
+	{
+		$this->campaign = $campaign;
+		$this->organization = $organization;
+		$this->keyword = $keyword;
+	}
 
 	/**
 	 * Execute the job.

--- a/app/Jobs/GeneratePrompt.php
+++ b/app/Jobs/GeneratePrompt.php
@@ -55,12 +55,13 @@ class GeneratePrompt extends TrackableJob
 	 * @param  string  $keyword
 	 * @return void
 	 */
-	public function __construct(Campaign $campaign, Organization $organization, string $keyword)
-	{
-		$this->campaign = $campaign;
-		$this->organization = $organization;
-		$this->keyword = $keyword;
-	}
+        public function __construct(Campaign $campaign, Organization $organization, string $keyword)
+        {
+                $this->campaign = $campaign;
+                $this->organization = $organization;
+                $this->keyword = $keyword;
+                $this->model = $campaign;
+        }
 
 	/**
 	 * Execute the job.

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Traits\BelongsToTeam;
+use App\Traits\HasJobStatus;
 
 class Campaign extends Model
 {
-	use HasFactory, BelongsToTeam;
+	use HasFactory, BelongsToTeam, HasJobStatus;
 
 	protected $fillable = [
 		'team_id',

--- a/resources/js/pages/teams/Create.vue
+++ b/resources/js/pages/teams/Create.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStore } from '@/stores/teamStore'
 import { useOrganizationStore } from '@/stores/organizationStore'
+import { useCampaignStore } from '@/stores/campaignStore'
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 import Button from '@/components/ui/Button.vue'
 import OrganizationSearch from '@/components/OrganizationSearch.vue'
@@ -11,7 +12,9 @@ import OrganizationLogo from '@/components/organizations/OrganizationLogo.vue'
 const router = useRouter()
 const teamStore = useTeamStore()
 const organizationStore = useOrganizationStore()
+const campaignStore = useCampaignStore()
 const isSubmitting = ref(false)
+const currentStep = ref('')
 
 // Organization data
 const organization = ref({
@@ -44,20 +47,42 @@ const deselectOrganization = () => {
 
 // Create team and organization
 const createTeamAndOrganization = async () => {
-	if (!organization.value.name) return
+        if (!organization.value.name) return
 
-	isSubmitting.value = true
-	try {
-        let team = await teamStore.createTeam({ name: organization.value.name })
-        await organizationStore.createAndOnboardOrganization(team.id, organization.value)
+        isSubmitting.value = true
+        try {
+                // Step 1: Create team
+                currentStep.value = 'Creating team...'
+                const team = await teamStore.createTeam({ name: organization.value.name })
 
-        await teamStore.switchTeam(team.id)
-        router.push({ name: 'home', params: { id: team.id } })
-	} catch (error) {
-		console.error('Error creating team and organization:', error)
-	} finally {
-		isSubmitting.value = false
-	}
+                // Step 2: Create organization
+                currentStep.value = 'Creating organization...'
+                const orgData = {
+                        name: organization.value.name,
+                        website: organization.value.website,
+                        logo: organization.value.logo,
+                        is_competitor: false
+                }
+                await organizationStore.createOwnedOrganization(team.id, orgData)
+
+                // Step 3: Create default campaign
+                currentStep.value = 'Setting up campaign...'
+                const campaign = await campaignStore.createDefaultCampaign(team.id, {
+                        location: organization.value.location,
+                        description: organization.value.description
+                })
+
+                // Step 4: Switch to new team and navigate
+                currentStep.value = 'Finalizing...'
+                await teamStore.switchTeam(team.id)
+                router.push({ name: 'home', params: { id: team.id, campaignId: campaign.id } })
+        } catch (error) {
+                console.error('Error creating team and organization:', error)
+                currentStep.value = ''
+        } finally {
+                isSubmitting.value = false
+                currentStep.value = ''
+        }
 }
 </script>
 
@@ -141,9 +166,10 @@ const createTeamAndOrganization = async () => {
 				</div>
 
 				<div class="mt-6 flex justify-end space-x-2">
-					<Button @click="createTeamAndOrganization" :disabled="isSubmitting || !organization.name" variant="dark">
-						{{ isSubmitting ? 'Creating...' : 'Create Team' }}
-					</Button>
+                <Button @click="createTeamAndOrganization" :disabled="isSubmitting || !organization.name" variant="dark">
+                        <span v-if="isSubmitting">{{ currentStep || 'Creating...' }}</span>
+                        <span v-else>Create Team</span>
+                </Button>
 				</div>
 			</div>
 		</div>

--- a/resources/js/stores/campaignStore.js
+++ b/resources/js/stores/campaignStore.js
@@ -36,6 +36,28 @@ export const useCampaignStore = defineStore('campaign', {
                         try {
                                 const response = await api.post(`/teams/${teamId}/campaigns`, campaignData)
                                 this.campaigns.push(response)
+
+                                if (response.is_default) {
+                                        this.currentCampaign = response
+                                        localStorage.setItem(`team_${teamId}_current_campaign`, JSON.stringify(response))
+                                }
+
+                                return response
+                        } catch (error) {
+                                this.error = error.message
+                                throw error
+                        }
+                },
+
+                async createDefaultCampaign(teamId, { location, description }) {
+                        try {
+                                const response = await api.post(`/teams/${teamId}/campaigns/default`, {
+                                        location,
+                                        description
+                                })
+                                this.campaigns.push(response)
+                                this.currentCampaign = response
+                                localStorage.setItem(`team_${teamId}_current_campaign`, JSON.stringify(response))
                                 return response
                         } catch (error) {
                                 this.error = error.message

--- a/resources/js/stores/organizationStore.js
+++ b/resources/js/stores/organizationStore.js
@@ -76,20 +76,20 @@ export const useOrganizationStore = defineStore('organization', () => {
 		}
 	}
 
-	async function createAndOnboardOrganization(teamId, organizationData) {
-		console.log('Creating and onboarding organization...')
-		isLoading.value = true
+        async function createOwnedOrganization(teamId, organizationData) {
+                console.log('Creating owned organization...')
+                isLoading.value = true
 
-		try {
-			const response = await api.post(`/teams/${teamId}/organizations-onboard`, organizationData)
-			return response
-		} catch (err) {
-			console.error('Error creating organization:', err)
-			throw err
-		} finally {
-			isLoading.value = false
-		}
-	}
+                try {
+                        const response = await api.post(`/teams/${teamId}/organizations-onboard`, organizationData)
+                        return response
+                } catch (err) {
+                        console.error('Error creating organization:', err)
+                        throw err
+                } finally {
+                        isLoading.value = false
+                }
+        }
 
 	async function updateOrganization(organizationId, organizationData) {
 		console.log('Updating organization ID:', organizationId)
@@ -195,9 +195,9 @@ export const useOrganizationStore = defineStore('organization', () => {
 		// Actions
 		fetchOrganizations,
 		fetchOrganization,
-		createOrganization,
-		createAndOnboardOrganization,
-		updateOrganization,
+                createOrganization,
+                createOwnedOrganization,
+                updateOrganization,
 		deleteOrganization,
 		fetchVisibilityMetrics,
 		setDateRange,

--- a/routes/api.php
+++ b/routes/api.php
@@ -74,8 +74,9 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::get('terms/{term}/prompts/{prompt}/responses', [TermResponsesController::class, 'index']);
 
 	// Campaigns
-	Route::get('teams/{team}/campaigns', [CampaignController::class, 'index']);
-	Route::post('teams/{team}/campaigns', [CampaignController::class, 'store']);
+        Route::get('teams/{team}/campaigns', [CampaignController::class, 'index']);
+        Route::post('teams/{team}/campaigns', [CampaignController::class, 'store']);
+        Route::post('teams/{team}/campaigns/default', [CampaignController::class, 'createDefault']);
 	Route::get('teams/{team}/campaigns/{campaign}', [CampaignController::class, 'show']);
 	Route::put('teams/{team}/campaigns/{campaign}', [CampaignController::class, 'update']);
 	Route::delete('teams/{team}/campaigns/{campaign}', [CampaignController::class, 'destroy']);

--- a/tests/Feature/Organization/OrganizationOnboardControllerTest.php
+++ b/tests/Feature/Organization/OrganizationOnboardControllerTest.php
@@ -11,7 +11,7 @@ use Laravel\Sanctum\Sanctum;
 
 uses(RefreshDatabase::class);
 
-it('onboards a new organization and dispatches a generate phrases job', function () {
+it('onboards a new organization and creates terms', function () {
 	Bus::fake();
 
 	$user = User::factory()->create();
@@ -32,5 +32,5 @@ it('onboards a new organization and dispatches a generate phrases job', function
 
 	expect(Organization::find($organizationId))->not->toBeNull();
 	expect(Term::where('organization_id', $organizationId)->count())->toBe(2);
-	expect(JobStatus::where('trackable_type', Organization::class)->count())->toBe(1);
+        expect(JobStatus::where('trackable_type', Organization::class)->count())->toBe(0);
 });


### PR DESCRIPTION
## Summary
- simplify OrganizationOnboardController to only create an organization
- move campaign creation logic into CampaignController and dispatch keyword jobs
- derive organization in GenerateCampaignKeywords job
- expose helper to track job model in GeneratePrompt job
- update Pinia stores and team creation page for new flow
- adjust API routes and tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_6883c17462a88323b0d8f4deacaa51c9