### PR TITLE
Scope job statuses by campaign

### DIFF
--- a/app/Http/Controllers/JobStatusController.php
+++ b/app/Http/Controllers/JobStatusController.php
@@ -20,9 +20,14 @@ class JobStatusController extends Controller
     {
         $teamId = $team->id;
 
+        $query = JobStatus::where('team_id', $teamId);
+
+        if ($request->filled('campaign_id')) {
+            $query->where('campaign_id', $request->input('campaign_id'));
+        }
+
         // Get job statuses for this team
-        $jobStatuses = JobStatus::where('team_id', $teamId)
-            ->orderBy('created_at', 'desc')
+        $jobStatuses = $query->orderBy('created_at', 'desc')
             ->limit(100)
             ->get();
 

--- a/app/Models/JobStatus.php
+++ b/app/Models/JobStatus.php
@@ -6,21 +6,24 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Traits\BelongsToTeam;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Campaign;
 
 class JobStatus extends Model
 {
 	use Prunable, HasFactory, BelongsToTeam;
 
-	protected $fillable = [
-		'job_id',
-		'job_class',
-		'job_batch_id',
-		'status',
-		'output',
-		'error',
-		'progress',
-		'team_id',
-	];
+        protected $fillable = [
+                'job_id',
+                'job_class',
+                'job_batch_id',
+                'status',
+                'output',
+                'error',
+                'progress',
+                'team_id',
+                'campaign_id',
+        ];
 
 	/**
 	 * Get the prunable model query.
@@ -76,8 +79,16 @@ class JobStatus extends Model
 	/**
 	 * Scope a query to only include cancelled jobs.
 	 */
-	public function scopeCancelled($query)
-	{
-		return $query->where('status', 'cancelled');
-	}
+        public function scopeCancelled($query)
+        {
+                return $query->where('status', 'cancelled');
+        }
+
+        /**
+         * Get the campaign that owns the job status.
+         */
+        public function campaign(): BelongsTo
+        {
+                return $this->belongsTo(Campaign::class);
+        }
 }

--- a/app/Traits/HasJobStatus.php
+++ b/app/Traits/HasJobStatus.php
@@ -42,13 +42,22 @@ trait HasJobStatus
 		$jobId = (string) Str::uuid();
 
 		// Create a job status record
-		$status = $this->jobStatuses()->create([
-			'job_id' => $jobId,
-			'job_class' => get_class($job),
-			'job_batch_id' => $batchId,
-			'status' => 'pending',
-			'team_id' => $this->team_id,
-		]);
+                $campaignId = null;
+
+                if (isset($this->campaign_id)) {
+                        $campaignId = $this->campaign_id;
+                } elseif (method_exists($this, 'organization')) {
+                        $campaignId = $this->organization->campaign_id ?? null;
+                }
+
+                $status = $this->jobStatuses()->create([
+                        'job_id' => $jobId,
+                        'job_class' => get_class($job),
+                        'job_batch_id' => $batchId,
+                        'status' => 'pending',
+                        'team_id' => $this->team_id,
+                        'campaign_id' => $campaignId,
+                ]);
 
 		return $status;
 	}

--- a/database/factories/JobStatusFactory.php
+++ b/database/factories/JobStatusFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\JobStatus;
 use App\Models\Team;
 use App\Models\Prompt;
+use App\Models\Campaign;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -19,6 +20,7 @@ class JobStatusFactory extends Factory
     {
         return [
             'team_id' => Team::factory(),
+            'campaign_id' => Campaign::factory(),
             'job_id' => (string) Str::uuid(),
             'job_class' => 'App\\Jobs\\ExampleJob',
             'job_batch_id' => null,

--- a/database/migrations/2025_08_05_000000_add_campaign_id_to_job_statuses_table.php
+++ b/database/migrations/2025_08_05_000000_add_campaign_id_to_job_statuses_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('job_statuses', function (Blueprint $table) {
+            $table->foreignId('campaign_id')->nullable()->after('team_id')->constrained()->cascadeOnDelete();
+            $table->index('campaign_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('job_statuses', function (Blueprint $table) {
+            $table->dropForeign(['campaign_id']);
+            $table->dropIndex(['campaign_id']);
+            $table->dropColumn('campaign_id');
+        });
+    }
+};

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -35,17 +35,32 @@ const handleDateRangeChange = (dateRange) => {
 	}
 }
 
-const processingJobsByClass = computed(() => jobStatusStore.processingJobsByClass)
+const processingJobsByClass = computed(() => {
+    const grouped = {}
+    const cid = Number(campaignId.value)
+    if (jobStatusStore.jobs) {
+        jobStatusStore.jobs
+            .filter((j) => j.campaign_id === cid && j.status === 'processing')
+            .forEach((job) => {
+                const jobClass = job.job_class || 'unknown'
+                if (!grouped[jobClass]) {
+                    grouped[jobClass] = []
+                }
+                grouped[jobClass].push(job)
+            })
+    }
+    return grouped
+})
 
 // Watch for job completions and refresh data
 watch(
-	() => jobStatusStore.completedJobs.length,
-	(newCount, oldCount) => {
-		if (newCount > oldCount) {
-			console.log('Jobs completed, refreshing visibility metrics')
-			fetchVisibilityData()
-		}
-	}
+        () => jobStatusStore.jobs.filter((j) => j.campaign_id === Number(campaignId.value) && j.status === 'completed').length,
+        (newCount, oldCount) => {
+                if (newCount > oldCount) {
+                        console.log('Jobs completed, refreshing visibility metrics')
+                        fetchVisibilityData()
+                }
+        }
 )
 
 // Computed property for the owned organization

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -19,22 +19,25 @@ const campaignId = computed(() => route.params.campaignId)
 
 // Get active jobs related to competitors
 const activeCompetitorJobs = computed(() => {
-	return jobStatusStore.jobs.filter(
-		(job) => job.job_class.includes('FindCompetitorsInResponseJob') && (job.status === 'pending' || job.status === 'processing')
-	)
+        const cid = Number(campaignId.value)
+        return jobStatusStore.jobs.filter(
+                (job) => job.campaign_id === cid && job.job_class.includes('FindCompetitorsInResponseJob') && (job.status === 'pending' || job.status === 'processing')
+        )
 })
 
 // Watch for competitor job completions
 watch(
-	() => jobStatusStore.jobs,
-	(newJobs, oldJobs) => {
-		// Check if any competitor job has just completed
-		const completedCompetitorJob = newJobs.some(
-			(job) =>
-				job.job_class.includes('FindCompetitorsInResponseJob') &&
-				job.status === 'completed' &&
-				oldJobs.find((oldJob) => oldJob.job_id === job.job_id)?.status !== 'completed'
-		)
+        () => jobStatusStore.jobs,
+        (newJobs, oldJobs) => {
+                // Check if any competitor job has just completed
+                const cid = Number(campaignId.value)
+                const completedCompetitorJob = newJobs.some(
+                        (job) =>
+                                job.campaign_id === cid &&
+                                job.job_class.includes('FindCompetitorsInResponseJob') &&
+                                job.status === 'completed' &&
+                                oldJobs.find((oldJob) => oldJob.job_id === job.job_id)?.status !== 'completed'
+                )
 
 		if (completedCompetitorJob) {
 			console.log('Competitor job completed, refreshing organizations')

--- a/resources/js/pages/prompts/Index.vue
+++ b/resources/js/pages/prompts/Index.vue
@@ -36,10 +36,11 @@ const sortOption = ref('default') // Default sort option
 // Using centralized date range from organizationStore
 
 const activePromptJobs = computed(() => {
-	const promptJobClasses = ['RunPromptJob', 'FindCompetitorsInResponseJob']
-	return (jobStatusStore.jobs || []).filter((job) => {
-		return promptJobClasses.some((className) => job.job_class.includes(className)) && (job.status === 'pending' || job.status === 'processing')
-	})
+        const promptJobClasses = ['RunPromptJob', 'FindCompetitorsInResponseJob']
+        const cid = Number(campaignId.value)
+        return (jobStatusStore.jobs || []).filter((job) => {
+                return job.campaign_id === cid && promptJobClasses.some((className) => job.job_class.includes(className)) && (job.status === 'pending' || job.status === 'processing')
+        })
 })
 
 watch(

--- a/tests/Feature/Job/JobStatusControllerTest.php
+++ b/tests/Feature/Job/JobStatusControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\JobStatus;
 use App\Models\Team;
+use App\Models\Campaign;
 use Laravel\Sanctum\Sanctum;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -14,9 +15,11 @@ it('returns job statuses for the authenticated team', function () {
 	$user->save();
 	Sanctum::actingAs($user);
 
-	JobStatus::factory()->count(3)->for($team)->create();
-	$otherTeam = Team::factory()->create();
-	JobStatus::factory()->count(2)->for($otherTeam)->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        JobStatus::factory()->count(3)->for($team)->for($campaign)->create();
+        $otherTeam = Team::factory()->create();
+        $otherCampaign = Campaign::factory()->for($otherTeam)->create();
+        JobStatus::factory()->count(2)->for($otherTeam)->for($otherCampaign)->create();
 
 	$response = $this->getJson("/api/teams/{$team->id}/jobs");
 
@@ -34,10 +37,11 @@ it('limits results to 100 in descending order', function () {
 	$user->save();
 	Sanctum::actingAs($user);
 
-	$jobs = JobStatus::factory()->for($team)
-		->count(105)
-		->sequence(fn($sequence) => ['created_at' => now()->addSeconds($sequence->index)])
-		->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        $jobs = JobStatus::factory()->for($team)->for($campaign)
+                ->count(105)
+                ->sequence(fn($sequence) => ['created_at' => now()->addSeconds($sequence->index)])
+                ->create();
 
 	$response = $this->getJson("/api/teams/{$team->id}/jobs");
 	$response->assertStatus(200)
@@ -52,7 +56,8 @@ it('cancels pending jobs for the authenticated team', function () {
 	$user->save();
 	Sanctum::actingAs($user);
 
-	JobStatus::factory()->count(2)->for($team)->state(['status' => 'pending'])->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        JobStatus::factory()->count(2)->for($team)->for($campaign)->state(['status' => 'pending'])->create();
 
 	$response = $this->postJson("/api/teams/{$team->id}/jobs/cancel");
 


### PR DESCRIPTION
## Summary
- track campaign_id on JobStatus records
- expose optional campaign filter via JobStatusController
- adjust job tracking trait to store campaign
- update factories and tests
- filter displayed jobs by campaign in Dashboard, Prompts and Organizations pages
- add migration for campaign_id on job_statuses

## Testing
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_b_6884285c00088323bca92e5a415ce0fe