### PR TITLE
Add minimal Laravel CMS core

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StorePageRequest;
+use App\Models\Page;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class PageController extends Controller
+{
+    public function index(): View
+    {
+        $pages = Page::orderByDesc('created_at')->get();
+
+        return view('admin.pages.index', compact('pages'));
+    }
+
+    public function create(): View
+    {
+        return view('admin.pages.create');
+    }
+
+    public function store(StorePageRequest $request): RedirectResponse
+    {
+        $page = Page::create($request->validated());
+
+        foreach ($request->input('content_blocks', []) as $index => $block) {
+            $page->contentBlocks()->create([
+                'block_type' => $block['type'],
+                'block_data' => $block['data'],
+                'sort_order' => $index,
+            ]);
+        }
+
+        return redirect()->route('admin.pages.index')->with('success', 'Page created successfully.');
+    }
+}

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Page;
+use Illuminate\View\View;
+
+class PageController extends Controller
+{
+    public function show(Page $page): View
+    {
+        $page->load(['contentBlocks' => function ($query) {
+            $query->orderBy('sort_order');
+        }]);
+
+        return view('pages.show', compact('page'));
+    }
+}

--- a/app/Http/Requests/StorePageRequest.php
+++ b/app/Http/Requests/StorePageRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'slug' => 'nullable|string|max:255|unique:pages,slug',
+            'intro' => 'nullable|string',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string|max:160',
+            'published_at' => 'nullable|date',
+            'content_blocks' => 'array',
+            'content_blocks.*.type' => 'required|in:text,image,cta',
+            'content_blocks.*.data' => 'required|array',
+        ];
+    }
+}

--- a/app/Models/ContentBlock.php
+++ b/app/Models/ContentBlock.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class ContentBlock extends Model
+{
+    protected $fillable = [
+        'blockable_id', 'blockable_type', 'block_type',
+        'block_data', 'sort_order'
+    ];
+
+    protected $casts = [
+        'block_data' => 'array',
+    ];
+
+    public function blockable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class Page extends Model
+{
+    protected $fillable = [
+        'title', 'slug', 'intro', 'meta_title',
+        'meta_description', 'published_at', 'parent_id'
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($page) {
+            if (empty($page->slug)) {
+                $page->slug = Str::slug($page->title);
+            }
+        });
+    }
+
+    public function contentBlocks(): MorphMany
+    {
+        return $this->morphMany(ContentBlock::class, 'blockable')->orderBy('sort_order');
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Page::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Page::class, 'parent_id');
+    }
+
+    public function scopePublished($query)
+    {
+        return $query->whereNotNull('published_at')->where('published_at', '<=', now());
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}

--- a/database/migrations/2025_07_28_000000_create_pages_table.php
+++ b/database/migrations/2025_07_28_000000_create_pages_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('intro')->nullable();
+            $table->string('meta_title')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->timestamps();
+
+            $table->index('slug');
+            $table->index('published_at');
+            $table->index('parent_id');
+            $table->foreign('parent_id')->references('id')->on('pages')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};

--- a/database/migrations/2025_07_28_000001_create_content_blocks_table.php
+++ b/database/migrations/2025_07_28_000001_create_content_blocks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('content_blocks', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('blockable');
+            $table->string('block_type');
+            $table->json('block_data');
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['blockable_id', 'blockable_type', 'sort_order']);
+            $table->index('block_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('content_blocks');
+    }
+};

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', 'CMS Admin')</title>
+    @vite(['resources/css/app.css'])
+</head>
+<body class="bg-gray-50">
+    <div class="max-w-4xl mx-auto py-8 px-4">
+        <h1 class="text-3xl font-bold mb-6">@yield('header')</h1>
+        @if(session('success'))
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+                {{ session('success') }}
+            </div>
+        @endif
+        @yield('content')
+    </div>
+</body>
+</html>

--- a/resources/views/admin/pages/create.blade.php
+++ b/resources/views/admin/pages/create.blade.php
@@ -1,0 +1,36 @@
+@extends('admin.layout')
+
+@section('header', 'Create Page')
+
+@section('content')
+<form action="{{ route('admin.pages.store') }}" method="POST" class="space-y-6">
+    @csrf
+    <div>
+        <label class="block mb-1 font-medium" for="title">Title</label>
+        <input type="text" name="title" id="title" class="w-full border-gray-300 rounded" required>
+    </div>
+    <div>
+        <label class="block mb-1 font-medium" for="slug">Slug</label>
+        <input type="text" name="slug" id="slug" class="w-full border-gray-300 rounded">
+    </div>
+    <div>
+        <label class="block mb-1 font-medium" for="intro">Intro</label>
+        <textarea name="intro" id="intro" class="w-full border-gray-300 rounded" rows="3"></textarea>
+    </div>
+    <div>
+        <label class="block mb-1 font-medium" for="meta_title">Meta Title</label>
+        <input type="text" name="meta_title" id="meta_title" class="w-full border-gray-300 rounded">
+    </div>
+    <div>
+        <label class="block mb-1 font-medium" for="meta_description">Meta Description</label>
+        <textarea name="meta_description" id="meta_description" class="w-full border-gray-300 rounded" rows="2"></textarea>
+    </div>
+    <div>
+        <label class="block mb-1 font-medium" for="published_at">Published At</label>
+        <input type="datetime-local" name="published_at" id="published_at" class="w-full border-gray-300 rounded">
+    </div>
+    <div>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Save</button>
+    </div>
+</form>
+@endsection

--- a/resources/views/admin/pages/index.blade.php
+++ b/resources/views/admin/pages/index.blade.php
@@ -1,0 +1,26 @@
+@extends('admin.layout')
+
+@section('header', 'Pages')
+
+@section('content')
+<a href="{{ route('admin.pages.create') }}" class="bg-blue-600 text-white px-4 py-2 rounded mb-4 inline-block">Create Page</a>
+
+<table class="min-w-full bg-white shadow rounded-lg overflow-hidden">
+    <thead class="bg-gray-100">
+        <tr>
+            <th class="px-4 py-2 text-left">Title</th>
+            <th class="px-4 py-2 text-left">Slug</th>
+            <th class="px-4 py-2 text-left">Published</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($pages as $page)
+            <tr class="border-b">
+                <td class="px-4 py-2">{{ $page->title }}</td>
+                <td class="px-4 py-2">{{ $page->slug }}</td>
+                <td class="px-4 py-2">{{ optional($page->published_at)->format('Y-m-d') }}</td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/content-blocks/cta.blade.php
+++ b/resources/views/content-blocks/cta.blade.php
@@ -1,0 +1,11 @@
+<div class="bg-blue-50 rounded-lg p-8 text-center my-12">
+    <h3 class="text-2xl font-bold text-gray-900 mb-4">
+        {{ $block->block_data['title'] ?? '' }}
+    </h3>
+    <p class="text-gray-700 mb-6 text-lg">
+        {{ $block->block_data['description'] ?? '' }}
+    </p>
+    <a href="{{ $block->block_data['button_url'] ?? '#' }}" class="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition-colors font-medium">
+        {{ $block->block_data['button_text'] ?? 'Learn More' }}
+    </a>
+</div>

--- a/resources/views/content-blocks/image.blade.php
+++ b/resources/views/content-blocks/image.blade.php
@@ -1,0 +1,8 @@
+<figure class="mb-8">
+    <img src="{{ $block->block_data['url'] }}" alt="{{ $block->block_data['alt'] ?? '' }}" class="w-full rounded-lg shadow-md">
+    @if(!empty($block->block_data['caption']))
+        <figcaption class="text-sm text-gray-600 mt-3 text-center">
+            {{ $block->block_data['caption'] }}
+        </figcaption>
+    @endif
+</figure>

--- a/resources/views/content-blocks/text.blade.php
+++ b/resources/views/content-blocks/text.blade.php
@@ -1,0 +1,3 @@
+<div class="prose max-w-none mb-8">
+    {!! $block->block_data['content'] ?? '' !!}
+</div>

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title')</title>
+    <meta name="description" content="@yield('meta_description')">
+    @vite(['resources/css/app.css'])
+</head>
+<body class="bg-gray-50">
+    @yield('content')
+</body>
+</html>

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.frontend')
+
+@section('title', $page->meta_title ?: $page->title)
+@section('meta_description', $page->meta_description)
+
+@section('content')
+<article class="max-w-4xl mx-auto px-4 py-12">
+    <header class="mb-12">
+        <h1 class="text-5xl font-bold text-gray-900 mb-4">{{ $page->title }}</h1>
+        @if($page->intro)
+            <p class="text-xl text-gray-600 leading-relaxed">{{ $page->intro }}</p>
+        @endif
+    </header>
+
+    <div class="prose prose-lg max-w-none">
+        @foreach($page->contentBlocks as $block)
+            @include('content-blocks.' . $block->block_type, ['block' => $block])
+        @endforeach
+    </div>
+</article>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PageController;
+use App\Http\Controllers\Admin\PageController as AdminPageController;
 
-Route::get('/{any?}', function () {
-    return view('app');
-})->where('any', '.*');
+Route::prefix('admin')->name('admin.')->group(function () {
+    Route::get('pages', [AdminPageController::class, 'index'])->name('pages.index');
+    Route::get('pages/create', [AdminPageController::class, 'create'])->name('pages.create');
+    Route::post('pages', [AdminPageController::class, 'store'])->name('pages.store');
+});
+
+Route::get('/pages/{page:slug}', [PageController::class, 'show'])->name('pages.show');


### PR DESCRIPTION
## Summary
- create migrations for `pages` and `content_blocks`
- implement `Page` and `ContentBlock` models
- add admin page controller and basic form request
- add public page controller and frontend layout
- create Blade templates for pages and content blocks
- wire up routes for admin page creation and page display

## Testing
- `php -l app/Models/Page.php`
- `php -l app/Models/ContentBlock.php`
- `php -l app/Http/Controllers/Admin/PageController.php`
- `php -l app/Http/Controllers/PageController.php`
- `php -l app/Http/Requests/StorePageRequest.php`
- `php -l routes/web.php`
- `php -l resources/views/pages/show.blade.php`

Composer install failed due to network restrictions, so application tests could not be run.

------
https://chatgpt.com/codex/tasks/task_b_6887bd2af1548323ac82df30276431f0