### PR TITLE
Add LLM agent pageview tracking

### DIFF
--- a/app/Http/Controllers/TrackingController.php
+++ b/app/Http/Controllers/TrackingController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PageView;
+use App\Services\AgentDetector;
+use App\Services\DomainNormalizer;
+use Illuminate\Http\Request;
+
+class TrackingController extends Controller
+{
+    public function track(Request $request)
+    {
+        $data = $request->validate([
+            'domain' => 'required|string',
+            'path' => 'required|string',
+        ]);
+
+        $normalized = DomainNormalizer::normalize($data['domain']);
+        $agent = $request->header('User-Agent');
+
+        $view = PageView::create([
+            'normalized_domain' => $normalized,
+            'path' => $data['path'],
+            'user_agent' => $agent ?? '',
+            'is_llm' => AgentDetector::isLLMAgent($agent),
+        ]);
+
+        return response()->json(['id' => $view->id], 201);
+    }
+}

--- a/app/Http/Controllers/WebsiteController.php
+++ b/app/Http/Controllers/WebsiteController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Website;
+use App\Models\PageView;
+use App\Services\DomainNormalizer;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
+
+class WebsiteController extends Controller
+{
+    public function index()
+    {
+        $websites = Auth::user()->websites()->get();
+        return response()->json($websites);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'domain' => 'required|string',
+        ]);
+        $data['domain'] = DomainNormalizer::normalize($data['domain']);
+        $website = Auth::user()->websites()->create($data);
+        return response()->json(['website' => $website], 201);
+    }
+
+    public function show(Request $request, Website $website)
+    {
+        if ($website->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $start = Carbon::parse($request->query('start', now()->subDays(7)));
+        $end = Carbon::parse($request->query('end', now()));
+
+        $viewsQuery = PageView::where('normalized_domain', $website->domain)
+            ->whereBetween('created_at', [$start, $end])
+            ->where('is_llm', true);
+
+        $total = $viewsQuery->count();
+        $byAgent = $viewsQuery->select('user_agent', DB::raw('count(*) as count'))
+            ->groupBy('user_agent')
+            ->orderByDesc('count')
+            ->get();
+
+        $embedCode = sprintf('<script src="%s/llm-tracker.js" defer></script>', config('app.url'));
+
+        return response()->json([
+            'website' => $website,
+            'embed_code' => $embedCode,
+            'stats' => [
+                'total' => $total,
+                'by_agent' => $byAgent,
+            ],
+        ]);
+    }
+}

--- a/app/Models/PageView.php
+++ b/app/Models/PageView.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PageView extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'normalized_domain',
+        'path',
+        'user_agent',
+        'is_llm',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Website;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -81,5 +82,13 @@ class User extends Authenticatable
     public function pendingTeamInvitations(): BelongsToMany
     {
         return $this->teams()->wherePivot('invitation_accepted', false);
+    }
+
+    /**
+     * Get the websites owned by the user.
+     */
+    public function websites(): HasMany
+    {
+        return $this->hasMany(Website::class);
     }
 }

--- a/app/Models/Website.php
+++ b/app/Models/Website.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Website extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'domain',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/AgentDetector.php
+++ b/app/Services/AgentDetector.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+class AgentDetector
+{
+    public static function isLLMAgent(?string $userAgent): bool
+    {
+        if (!$userAgent || !is_string($userAgent)) {
+            return false;
+        }
+
+        $patterns = [
+            // OpenAI
+            '/gptbot/i', '/chatgpt-user/i', '/oai-searchbot/i',
+            // Anthropic
+            '/anthropic-ai/i', '/claudebot/i', '/claude-web/i', '/claude-user/i',
+            // Google AI
+            '/google-extended/i', '/googleother/i', '/googleagent-mariner/i',
+            // Other Major Providers
+            '/perplexitybot/i', '/perplexity-user/i', '/mistralai-user/i',
+            '/meta-externalagent/i', '/applebot-extended/i', '/amazonbot/i',
+            // Generic patterns
+            '/\bai\s*bot\b/i', '/\bai\s*crawler/i', '/language\s*model/i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $userAgent)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Services/DomainNormalizer.php
+++ b/app/Services/DomainNormalizer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+class DomainNormalizer
+{
+    public static function normalize(string $url): string
+    {
+        // Remove protocol and www prefix
+        $domain = preg_replace('#^https?://(?:www\.)?(.+)#i', '$1', $url);
+        $domain = explode('/', $domain)[0];
+        return strtolower(trim($domain));
+    }
+}

--- a/database/migrations/2025_05_20_000003_create_page_views_table.php
+++ b/database/migrations/2025_05_20_000003_create_page_views_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('page_views', function (Blueprint $table) {
+            $table->id();
+            $table->string('normalized_domain');
+            $table->string('path');
+            $table->text('user_agent');
+            $table->boolean('is_llm')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('page_views');
+    }
+};

--- a/database/migrations/2025_05_20_000004_create_websites_table.php
+++ b/database/migrations/2025_05_20_000004_create_websites_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('websites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->string('domain')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('websites');
+    }
+};

--- a/public/llm-tracker.js
+++ b/public/llm-tracker.js
@@ -1,0 +1,23 @@
+(function(){
+    function send(){
+        var payload = JSON.stringify({
+            domain: location.hostname,
+            path: location.pathname
+        });
+        if(navigator.sendBeacon){
+            navigator.sendBeacon('/api/track', payload);
+        }else{
+            fetch('/api/track', {
+                method:'POST',
+                headers:{'Content-Type':'application/json'},
+                body: payload,
+                keepalive: true
+            });
+        }
+    }
+    if(document.readyState==='complete'){
+        send();
+    }else{
+        window.addEventListener('load', send);
+    }
+})();

--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -21,6 +21,7 @@ const logout = async () => {
         <div v-if="isAuthenticated" class="flex items-center space-x-4 ml-6">
           <router-link to="/" class="text-sm hover:text-neutral-300">Dashboard</router-link>
           <router-link to="/teams" class="text-sm hover:text-neutral-300">Teams</router-link>
+          <router-link to="/websites" class="text-sm hover:text-neutral-300">Websites</router-link>
         </div>
       </div>
       

--- a/resources/js/pages/websites/Index.vue
+++ b/resources/js/pages/websites/Index.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+import Button from '@/components/ui/Button.vue'
+import { useWebsiteStore } from '@/stores/websiteStore'
+
+const store = useWebsiteStore()
+const showModal = ref(false)
+const name = ref('')
+const domain = ref('')
+const submitting = ref(false)
+
+onMounted(() => {
+  store.fetchWebsites()
+})
+
+const createWebsite = async () => {
+  if (!name.value || !domain.value) return
+  submitting.value = true
+  try {
+    await store.createWebsite({ name: name.value, domain: domain.value })
+    name.value = ''
+    domain.value = ''
+    showModal.value = false
+  } catch (e) {
+    console.error(e)
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <DefaultLayout>
+    <div class="container mx-auto py-8 px-4">
+      <div class="flex justify-between items-center mb-8">
+        <h1 class="text-2xl font-bold">Websites</h1>
+        <Button @click="showModal = true">Add Website</Button>
+      </div>
+
+      <div v-if="store.isLoading" class="py-8 text-center">Loading...</div>
+      <div v-else-if="store.error" class="py-8 text-red-600">{{ store.error }}</div>
+      <div v-else>
+        <div v-if="store.websites.length === 0" class="text-neutral-500">No websites yet.</div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div v-for="site in store.websites" :key="site.id" class="p-4 bg-neutral-100 rounded shadow">
+            <div class="font-medium">{{ site.name }}</div>
+            <div class="text-sm text-neutral-600">{{ site.domain }}</div>
+            <router-link :to="{ name: 'websites.show', params: { id: site.id } }" class="text-blue-600 text-sm mt-2 inline-block">View</router-link>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div class="bg-white rounded-lg p-6 w-full max-w-md">
+        <h2 class="text-xl font-bold mb-4">Add Website</h2>
+        <div class="mb-4">
+          <label class="block text-sm mb-1">Name</label>
+          <input v-model="name" type="text" class="w-full border px-3 py-2 rounded" />
+        </div>
+        <div class="mb-4">
+          <label class="block text-sm mb-1">Domain</label>
+          <input v-model="domain" type="text" class="w-full border px-3 py-2 rounded" placeholder="example.com" />
+        </div>
+        <div class="flex justify-end space-x-2">
+          <Button variant="secondary" @click="showModal = false">Cancel</Button>
+          <Button @click="createWebsite" :disabled="submitting">{{ submitting ? 'Saving...' : 'Save' }}</Button>
+        </div>
+      </div>
+    </div>
+  </DefaultLayout>
+</template>

--- a/resources/js/pages/websites/Show.vue
+++ b/resources/js/pages/websites/Show.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { onMounted, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+import { useWebsiteStore } from '@/stores/websiteStore'
+
+const store = useWebsiteStore()
+const route = useRoute()
+const websiteId = computed(() => route.params.id)
+
+onMounted(() => {
+  store.fetchWebsite(websiteId.value)
+})
+</script>
+
+<template>
+  <DefaultLayout>
+    <div class="container mx-auto py-8 px-4" v-if="store.currentWebsite">
+      <h1 class="text-2xl font-bold mb-4">{{ store.currentWebsite.website.name }}</h1>
+      <p class="mb-4 text-sm text-neutral-600">Domain: {{ store.currentWebsite.website.domain }}</p>
+      <div class="mb-6">
+        <h2 class="font-semibold mb-2">Embed Code</h2>
+        <pre class="bg-neutral-100 p-4 rounded text-sm overflow-x-auto"><code>{{ store.currentWebsite.embed_code }}</code></pre>
+      </div>
+      <div>
+        <h2 class="font-semibold mb-2">Stats (last 7 days)</h2>
+        <p class="mb-2">Total LLM Page Views: {{ store.currentWebsite.stats.total }}</p>
+        <table class="min-w-full bg-white border border-neutral-200">
+          <thead>
+            <tr class="bg-neutral-100 text-left text-sm">
+              <th class="px-3 py-2 border-b">User Agent</th>
+              <th class="px-3 py-2 border-b">Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in store.currentWebsite.stats.by_agent" :key="item.user_agent" class="text-sm">
+              <td class="border-b px-3 py-2">{{ item.user_agent }}</td>
+              <td class="border-b px-3 py-2">{{ item.count }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </DefaultLayout>
+</template>

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -6,6 +6,8 @@ import Login from '@/pages/auth/Login.vue';
 import Register from '@/pages/auth/Register.vue';
 import TeamsIndex from '@/pages/teams/Index.vue';
 import TeamShow from '@/pages/teams/Show.vue';
+import WebsitesIndex from '@/pages/websites/Index.vue';
+import WebsiteShow from '@/pages/websites/Show.vue';
 
 const routes = [
   {
@@ -36,6 +38,18 @@ const routes = [
     path: '/teams/:id',
     name: 'teams.show',
     component: TeamShow,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/websites',
+    name: 'websites.index',
+    component: WebsitesIndex,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/websites/:id',
+    name: 'websites.show',
+    component: WebsiteShow,
     meta: { requiresAuth: true }
   },
 ];

--- a/resources/js/stores/websiteStore.js
+++ b/resources/js/stores/websiteStore.js
@@ -1,0 +1,56 @@
+import { defineStore } from 'pinia'
+import api from '@/services/api'
+
+export const useWebsiteStore = defineStore('website', {
+  state: () => ({
+    websites: [],
+    currentWebsite: null,
+    isLoading: false,
+    error: null
+  }),
+
+  actions: {
+    async fetchWebsites() {
+      this.isLoading = true
+      this.error = null
+      try {
+        const data = await api.get('/websites')
+        this.websites = data
+      } catch (e) {
+        this.error = e.message || 'Failed to fetch websites'
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    async createWebsite(payload) {
+      this.isLoading = true
+      this.error = null
+      try {
+        const res = await api.post('/websites', payload)
+        this.websites.push(res.website)
+        return res.website
+      } catch (e) {
+        this.error = e.message || 'Failed to create website'
+        throw e
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    async fetchWebsite(id, params = {}) {
+      this.isLoading = true
+      this.error = null
+      try {
+        const res = await api.get(`/websites/${id}`, { params })
+        this.currentWebsite = res
+        return res
+      } catch (e) {
+        this.error = e.message || 'Failed to fetch website'
+        throw e
+      } finally {
+        this.isLoading = false
+      }
+    }
+  }
+})

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,11 +4,14 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\TeamController;
+use App\Http\Controllers\TrackingController;
+use App\Http\Controllers\WebsiteController;
 
 // Public routes
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 Route::get('/invitations/verify', [InvitationController::class, 'verify']);
+Route::post('/track', [TrackingController::class, 'track']);
 
 // Protected routes
 Route::middleware('auth:sanctum')->group(function () {
@@ -23,4 +26,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('teams/{team}/decline-invitation', [TeamController::class, 'declineInvitation']);
     Route::delete('teams/{team}/members/{user}', [TeamController::class, 'removeMember']);
     Route::put('teams/{team}/members/{user}/role', [TeamController::class, 'updateMemberRole']);
+
+    // Website routes
+    Route::get('websites', [WebsiteController::class, 'index']);
+    Route::post('websites', [WebsiteController::class, 'store']);
+    Route::get('websites/{website}', [WebsiteController::class, 'show']);
 });

--- a/tests/Feature/TrackingTest.php
+++ b/tests/Feature/TrackingTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\PageView;
+use Illuminate\Support\Facades\Artisan;
+
+it('stores page view with normalized domain and llm detection', function () {
+    // skip if migrations cannot run
+    try {
+        Artisan::call('migrate');
+    } catch (Throwable $e) {
+        $this->markTestSkipped('Migrations failed: ' . $e->getMessage());
+    }
+
+    $response = $this->postJson('/api/track', [
+        'domain' => 'https://www.Example.COM',
+        'path' => '/test'
+    ], [
+        'User-Agent' => 'ChatGPT-User/2.0'
+    ]);
+
+    $response->assertStatus(201);
+    $this->assertDatabaseHas('page_views', [
+        'normalized_domain' => 'example.com',
+        'path' => '/test',
+        'is_llm' => true
+    ]);
+});

--- a/tests/Feature/WebsiteTest.php
+++ b/tests/Feature/WebsiteTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+
+it('creates website and lists stats', function () {
+    try {
+        Artisan::call('migrate');
+    } catch (Throwable $e) {
+        $this->markTestSkipped('Migrations failed: ' . $e->getMessage());
+    }
+
+    $user = User::factory()->create();
+    $token = $user->createToken('auth_token')->plainTextToken;
+
+    $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+        ->postJson('/api/websites', [
+            'name' => 'My Site',
+            'domain' => 'https://Example.com',
+        ]);
+
+    $response->assertStatus(201);
+    $websiteId = $response->json('website.id');
+
+    $this->withHeaders([
+        'Authorization' => 'Bearer ' . $token,
+    ])->getJson("/api/websites/{$websiteId}")
+      ->assertStatus(200)
+      ->assertJsonStructure(['website', 'embed_code', 'stats']);
+});


### PR DESCRIPTION
## Summary
- detect LLM agents via user agent
- normalize domains for multi-site analytics
- add PageView model, migration and controller
- expose `/api/track` endpoint
- lightweight JS tracker to send page views
- tests for tracking controller
- add website management pages and stats

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_688854835ccc8323bb92489fc8ab024e