### PR TITLE
Implement basic AI bot accessibility checker

### DIFF
--- a/app/Http/Controllers/Api/WebsiteController.php
+++ b/app/Http/Controllers/Api/WebsiteController.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\CheckBotAccessibilityJob;
+use App\Models\Website;
+use Illuminate\Http\Request;
+
+class WebsiteController extends Controller
+{
+    public function index()
+    {
+        return Website::orderBy('created_at','desc')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'domain' => 'required|string',
+            'base_url' => 'required|url',
+        ]);
+        $data['protocol'] = parse_url($data['base_url'], PHP_URL_SCHEME) ?: 'https';
+        $website = Website::create($data);
+        return response()->json($website, 201);
+    }
+
+    public function checkBots(Website $website)
+    {
+        CheckBotAccessibilityJob::dispatch($website);
+        return response()->json(['message'=>'Bot accessibility check initiated']);
+    }
+
+    public function results(Website $website)
+    {
+        return $website->accessibilityResults()->with('userAgent')->orderBy('checked_at','desc')->get();
+    }
+}

--- a/app/Http/Resources/BotAccessibilityResultResource.php
+++ b/app/Http/Resources/BotAccessibilityResultResource.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class BotAccessibilityResultResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'user_agent' => $this->userAgent->name ?? null,
+            'robots_txt_allowed' => $this->robots_txt_allowed,
+            'http_accessible' => $this->http_accessible,
+            'firewall_detected' => $this->firewall_detected,
+            'checked_at' => $this->checked_at,
+            'waf_type' => $this->waf_type,
+            'blocking_method' => $this->blocking_method,
+        ];
+    }
+}

--- a/app/Jobs/CheckBotAccessibilityJob.php
+++ b/app/Jobs/CheckBotAccessibilityJob.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Jobs;
+
+use App\Models\Website;
+use App\Models\UserAgent;
+use App\Services\BotAccessibility\BotAccessibilityService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class CheckBotAccessibilityJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Website $website, public array $userAgentIds = [])
+    {
+        $this->onQueue('bot-checking');
+    }
+
+    public function handle(BotAccessibilityService $service): void
+    {
+        $query = UserAgent::query();
+        if (!empty($this->userAgentIds)) {
+            $query->whereIn('id', $this->userAgentIds);
+        } else {
+            $query->where('is_active', true)->aiBots();
+        }
+        $agents = $query->get();
+        foreach ($agents as $agent) {
+            $service->checkBotAccess($this->website, $agent);
+        }
+        $this->website->update(['last_checked_at' => now()]);
+    }
+}

--- a/app/Models/BotAccessibilityResult.php
+++ b/app/Models/BotAccessibilityResult.php
@@ -1,0 +1,47 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BotAccessibilityResult extends Model
+{
+    protected $fillable = [
+        'website_id',
+        'user_agent_id',
+        'url',
+        'url_hash',
+        'robots_txt_allowed',
+        'robots_txt_status_code',
+        'robots_txt_content',
+        'robots_txt_rules',
+        'http_accessible',
+        'http_status_code',
+        'response_time_ms',
+        'response_headers',
+        'firewall_detected',
+        'blocking_method',
+        'waf_type',
+        'detection_confidence',
+        'error_message',
+        'checked_at'
+    ];
+
+    protected $casts = [
+        'robots_txt_allowed' => 'boolean',
+        'http_accessible' => 'boolean',
+        'firewall_detected' => 'boolean',
+        'robots_txt_rules' => 'array',
+        'checked_at' => 'datetime',
+    ];
+
+    public function website(): BelongsTo
+    {
+        return $this->belongsTo(Website::class);
+    }
+
+    public function userAgent(): BelongsTo
+    {
+        return $this->belongsTo(UserAgent::class);
+    }
+}

--- a/app/Models/UserAgent.php
+++ b/app/Models/UserAgent.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UserAgent extends Model
+{
+    protected $fillable = [
+        'name', 'user_agent_string', 'user_agent_hash', 'type', 'category', 'is_active', 'metadata'
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function accessibilityResults(): HasMany
+    {
+        return $this->hasMany(BotAccessibilityResult::class);
+    }
+
+    public function scopeAiBots($query)
+    {
+        return $query->where('type', 'ai_bot');
+    }
+}

--- a/app/Models/Website.php
+++ b/app/Models/Website.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Website extends Model
+{
+    protected $fillable = [
+        'domain', 'protocol', 'base_url', 'status', 'crawl_settings', 'last_checked_at'
+    ];
+
+    protected $casts = [
+        'crawl_settings' => 'array',
+        'last_checked_at' => 'datetime',
+    ];
+
+    public function accessibilityResults(): HasMany
+    {
+        return $this->hasMany(BotAccessibilityResult::class);
+    }
+}

--- a/app/Services/BotAccessibility/BotAccessibilityService.php
+++ b/app/Services/BotAccessibility/BotAccessibilityService.php
@@ -1,0 +1,94 @@
+<?php
+namespace App\Services\BotAccessibility;
+
+use App\Models\{Website,UserAgent,BotAccessibilityResult};
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class BotAccessibilityService
+{
+    public function __construct(
+        private RobotsTxtParser $parser,
+        private FirewallDetector $firewall
+    ) {}
+
+    public function checkBotAccess(Website $website, UserAgent $agent): array
+    {
+        $results = [
+            'robots_txt' => $this->checkRobots($website, $agent),
+        ];
+        $http = $this->testHttp($website, $agent);
+        $results['http_access'] = $http;
+        $results['firewall'] = $http['firewall'];
+
+        $this->store($website, $agent, $results);
+        return $results;
+    }
+
+    private function checkRobots(Website $website, UserAgent $agent): array
+    {
+        $url = rtrim($website->base_url,'/') . '/robots.txt';
+        try {
+            $response = Http::timeout(15)->get($url);
+            $body = $response->body();
+            $allowed = $this->parser->isPathAllowed($body, $agent->user_agent_string, '/');
+            return [
+                'allowed' => $allowed,
+                'status_code' => $response->status(),
+                'content' => $body,
+                'parsed_rules' => $this->parser->parseRules($body),
+            ];
+        } catch (\Exception $e) {
+            return [ 'allowed' => true, 'status_code'=>null, 'error'=>$e->getMessage() ];
+        }
+    }
+
+    private function testHttp(Website $website, UserAgent $agent): array
+    {
+        try {
+            $start = microtime(true);
+            $response = Http::withHeaders([
+                'User-Agent' => $agent->user_agent_string,
+            ])->timeout(30)->get($website->base_url);
+            $time = (int)((microtime(true)-$start)*1000);
+            $firewall = $this->firewall->analyzeResponse($response->status(), $response->headers(), $response->body());
+            return [
+                'accessible' => !$firewall['blocked'],
+                'status_code' => $response->status(),
+                'response_time' => $time,
+                'headers' => $response->headers(),
+                'firewall' => $firewall,
+            ];
+        } catch (\Exception $e) {
+            return [
+                'accessible' => false,
+                'error' => $e->getMessage(),
+                'firewall' => ['blocked'=>false,'method'=>null,'waf_type'=>null,'confidence'=>0],
+            ];
+        }
+    }
+
+    private function store(Website $website, UserAgent $agent, array $results): void
+    {
+        BotAccessibilityResult::create([
+            'website_id' => $website->id,
+            'user_agent_id' => $agent->id,
+            'url' => $website->base_url,
+            'url_hash' => hash('sha256', $website->base_url),
+            'robots_txt_allowed' => $results['robots_txt']['allowed'],
+            'robots_txt_status_code' => $results['robots_txt']['status_code'] ?? null,
+            'robots_txt_content' => $results['robots_txt']['content'] ?? null,
+            'robots_txt_rules' => $results['robots_txt']['parsed_rules'] ?? null,
+            'http_accessible' => $results['http_access']['accessible'],
+            'http_status_code' => $results['http_access']['status_code'] ?? null,
+            'response_time_ms' => $results['http_access']['response_time'] ?? null,
+            'response_headers' => json_encode($results['http_access']['headers'] ?? []),
+            'firewall_detected' => $results['firewall']['blocked'] ?? false,
+            'blocking_method' => $results['firewall']['method'] ?? null,
+            'waf_type' => $results['firewall']['waf_type'] ?? null,
+            'detection_confidence' => $results['firewall']['confidence'] ?? null,
+            'error_message' => $results['http_access']['error'] ?? $results['robots_txt']['error'] ?? null,
+            'checked_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/BotAccessibility/FirewallDetector.php
+++ b/app/Services/BotAccessibility/FirewallDetector.php
@@ -1,0 +1,52 @@
+<?php
+namespace App\Services\BotAccessibility;
+
+class FirewallDetector
+{
+    private array $signatures = [
+        'cloudflare' => ['cf-ray','cloudflare'],
+        'sucuri' => ['x-sucuri-id','sucuri'],
+        'incapsula' => ['x-iinfo','incap_ses'],
+    ];
+
+    public function analyzeResponse(int $statusCode, array $headers, string $content): array
+    {
+        $blocked = false;
+        $method = null;
+        $type = null;
+        $confidence = 0;
+
+        if (in_array($statusCode, [403,429,503])) {
+            $blocked = true;
+            $method = 'status_code';
+            $confidence = 0.8;
+        }
+
+        foreach ($this->signatures as $name => $checks) {
+            foreach ($checks as $check) {
+                foreach ($headers as $h => $v) {
+                    if (str_contains(strtolower($h), strtolower($check))) {
+                        $blocked = true;
+                        $method = 'waf_detected';
+                        $type = $name;
+                        $confidence = 0.9;
+                        break 3;
+                    }
+                }
+                if (str_contains(strtolower($content), strtolower($check))) {
+                    $blocked = true;
+                    $method = 'content';
+                    $type = $name;
+                    $confidence = max($confidence,0.8);
+                }
+            }
+        }
+
+        return [
+            'blocked' => $blocked,
+            'method' => $method,
+            'waf_type' => $type,
+            'confidence' => $confidence,
+        ];
+    }
+}

--- a/app/Services/BotAccessibility/RobotsTxtParser.php
+++ b/app/Services/BotAccessibility/RobotsTxtParser.php
@@ -1,0 +1,49 @@
+<?php
+namespace App\Services\BotAccessibility;
+
+class RobotsTxtParser
+{
+    public function parseRules(string $robotsTxt): array
+    {
+        $lines = preg_split('/\r?\n/', $robotsTxt);
+        $rules = [];
+        $currentAgent = null;
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+            if (preg_match('/^user-agent:\s*(.+)$/i', $line, $m)) {
+                $currentAgent = strtolower(trim($m[1]));
+                $rules[$currentAgent] = $rules[$currentAgent] ?? ['allow'=>[], 'disallow'=>[]];
+            } elseif (preg_match('/^(allow|disallow):\s*(.*)$/i', $line, $m)) {
+                if ($currentAgent) {
+                    $rules[$currentAgent][strtolower($m[1])][] = trim($m[2]);
+                }
+            }
+        }
+        return $rules;
+    }
+
+    public function isPathAllowed(string $robotsTxt, string $userAgent, string $path): bool
+    {
+        $rules = $this->parseRules($robotsTxt);
+        $userAgent = strtolower($userAgent);
+        $applicable = $rules[$userAgent] ?? $rules['*'] ?? null;
+        if (!$applicable) {
+            return true;
+        }
+        foreach ($applicable['disallow'] as $pattern) {
+            if ($pattern !== '' && str_starts_with($path, $pattern)) {
+                foreach ($applicable['allow'] as $allow) {
+                    if (str_starts_with($path, $allow) && strlen($allow) >= strlen($pattern)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/database/migrations/2025_07_30_000001_create_websites_table.php
+++ b/database/migrations/2025_07_30_000001_create_websites_table.php
@@ -1,0 +1,27 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('websites', function (Blueprint $table) {
+            $table->id();
+            $table->string('domain')->unique();
+            $table->string('protocol', 10)->default('https');
+            $table->text('base_url');
+            $table->enum('status', ['active','inactive','suspended'])->default('active');
+            $table->json('crawl_settings')->nullable();
+            $table->timestamp('last_checked_at')->nullable();
+            $table->timestamps();
+            $table->index(['status','last_checked_at']);
+            $table->index('domain');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('websites');
+    }
+};

--- a/database/migrations/2025_07_30_000002_create_user_agents_table.php
+++ b/database/migrations/2025_07_30_000002_create_user_agents_table.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('user_agents', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100)->unique();
+            $table->text('user_agent_string');
+            $table->string('user_agent_hash', 64)->unique();
+            $table->enum('type', ['search_engine','ai_bot','social_media','other']);
+            $table->enum('category', ['good_bot','bad_bot','unknown'])->default('unknown');
+            $table->boolean('is_active')->default(true);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->index(['type','is_active']);
+            $table->index(['category','is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_agents');
+    }
+};

--- a/database/migrations/2025_07_30_000003_create_bot_accessibility_results_table.php
+++ b/database/migrations/2025_07_30_000003_create_bot_accessibility_results_table.php
@@ -1,0 +1,41 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('bot_accessibility_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('website_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_agent_id')->constrained()->onDelete('cascade');
+            $table->text('url');
+            $table->string('url_hash', 64)->index();
+            $table->boolean('robots_txt_allowed')->nullable();
+            $table->integer('robots_txt_status_code')->nullable();
+            $table->text('robots_txt_content')->nullable();
+            $table->json('robots_txt_rules')->nullable();
+            $table->boolean('http_accessible')->nullable();
+            $table->integer('http_status_code')->nullable();
+            $table->integer('response_time_ms')->nullable();
+            $table->text('response_headers')->nullable();
+            $table->boolean('firewall_detected')->default(false);
+            $table->string('blocking_method')->nullable();
+            $table->string('waf_type')->nullable();
+            $table->decimal('detection_confidence', 3, 2)->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamp('checked_at');
+            $table->timestamps();
+            $table->index(['website_id','checked_at']);
+            $table->index(['user_agent_id','robots_txt_allowed']);
+            $table->index(['http_accessible','firewall_detected']);
+            $table->unique(['website_id','url_hash','user_agent_id','checked_at'], 'unique_result');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bot_accessibility_results');
+    }
+};

--- a/database/seeders/AiBotUserAgentSeeder.php
+++ b/database/seeders/AiBotUserAgentSeeder.php
@@ -1,0 +1,29 @@
+<?php
+namespace Database\Seeders;
+
+use App\Models\UserAgent;
+use Illuminate\Database\Seeder;
+
+class AiBotUserAgentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $bots = [
+            ['name' => 'GPTBot', 'user_agent_string' => 'GPTBot/1.0; +https://openai.com/gptbot'],
+            ['name' => 'ClaudeBot', 'user_agent_string' => 'ClaudeBot/1.0; +claudebot@anthropic.com'],
+            ['name' => 'BingBot', 'user_agent_string' => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+        ];
+        foreach ($bots as $bot) {
+            UserAgent::updateOrCreate(
+                ['name' => $bot['name']],
+                [
+                    'user_agent_string' => $bot['user_agent_string'],
+                    'user_agent_hash' => hash('sha256', $bot['user_agent_string']),
+                    'type' => 'ai_bot',
+                    'category' => 'good_bot',
+                    'is_active' => true,
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\AiBotUserAgentSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(AiBotUserAgentSeeder::class);
     }
 }

--- a/resources/js/pages/websites/Index.vue
+++ b/resources/js/pages/websites/Index.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import DefaultLayout from '@/layouts/DefaultLayout.vue'
+import { useWebsiteStore } from '@/stores/websiteStore'
+
+const store = useWebsiteStore()
+const newDomain = ref('')
+const newUrl = ref('')
+const results = ref([])
+
+onMounted(() => {
+  store.fetchWebsites()
+})
+
+async function addSite() {
+  await store.addWebsite({ domain: newDomain.value, base_url: newUrl.value })
+  newDomain.value = ''
+  newUrl.value = ''
+}
+
+async function runCheck(id) {
+  await store.checkWebsite(id)
+  results.value = await store.loadResults(id)
+}
+</script>
+
+<template>
+  <DefaultLayout>
+    <div class="p-4">
+      <h2 class="text-xl mb-2">Websites</h2>
+      <div class="mb-4 flex gap-2">
+        <input v-model="newDomain" placeholder="Domain" class="border px-2" />
+        <input v-model="newUrl" placeholder="Base URL" class="border px-2" />
+        <button @click="addSite" class="bg-blue-500 text-white px-2">Add</button>
+      </div>
+      <ul>
+        <li v-for="site in store.websites" :key="site.id" class="mb-2">
+          <span>{{ site.domain }}</span>
+          <button @click="runCheck(site.id)" class="ml-2 text-sm underline">Check</button>
+        </li>
+      </ul>
+      <div v-if="results.length" class="mt-4">
+        <h3 class="font-bold">Results</h3>
+        <ul>
+          <li v-for="r in results" :key="r.id" class="text-sm">
+            {{ r.user_agent }} - robots allow: {{ r.robots_txt_allowed }}, http accessible: {{ r.http_accessible }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </DefaultLayout>
+</template>

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -6,6 +6,7 @@ import Login from '@/pages/auth/Login.vue';
 import Register from '@/pages/auth/Register.vue';
 import TeamsIndex from '@/pages/teams/Index.vue';
 import TeamShow from '@/pages/teams/Show.vue';
+import WebsitesIndex from '@/pages/websites/Index.vue';
 
 const routes = [
   {
@@ -36,6 +37,12 @@ const routes = [
     path: '/teams/:id',
     name: 'teams.show',
     component: TeamShow,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/websites',
+    name: 'websites.index',
+    component: WebsitesIndex,
     meta: { requiresAuth: true }
   },
 ];

--- a/resources/js/stores/websiteStore.js
+++ b/resources/js/stores/websiteStore.js
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import api from '@/services/api'
+
+export const useWebsiteStore = defineStore('website', {
+  state: () => ({
+    websites: [],
+    loading: false,
+    error: null
+  }),
+  actions: {
+    async fetchWebsites() {
+      this.loading = true
+      try {
+        const data = await api.get('/websites')
+        this.websites = data
+      } catch (e) {
+        this.error = e.message
+      } finally {
+        this.loading = false
+      }
+    },
+    async addWebsite(payload) {
+      const site = await api.post('/websites', payload)
+      this.websites.unshift(site)
+    },
+    async checkWebsite(id) {
+      await api.post(`/websites/${id}/check-bots`)
+    },
+    async loadResults(id) {
+      return await api.get(`/websites/${id}/results`)
+    }
+  }
+})

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,4 +23,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('teams/{team}/decline-invitation', [TeamController::class, 'declineInvitation']);
     Route::delete('teams/{team}/members/{user}', [TeamController::class, 'removeMember']);
     Route::put('teams/{team}/members/{user}/role', [TeamController::class, 'updateMemberRole']);
+
+    // Website bot accessibility routes
+    Route::get('websites', [\App\Http\Controllers\Api\WebsiteController::class, 'index']);
+    Route::post('websites', [\App\Http\Controllers\Api\WebsiteController::class, 'store']);
+    Route::post('websites/{website}/check-bots', [\App\Http\Controllers\Api\WebsiteController::class, 'checkBots']);
+    Route::get('websites/{website}/results', [\App\Http\Controllers\Api\WebsiteController::class, 'results']);
 });

--- a/tests/Feature/BotAccessibilityTest.php
+++ b/tests/Feature/BotAccessibilityTest.php
@@ -1,0 +1,25 @@
+<?php
+use App\Models\Website;
+use App\Models\UserAgent;
+use App\Jobs\CheckBotAccessibilityJob;
+use Illuminate\Support\Facades\Http;
+
+it('stores accessibility results', function () {
+    Http::fake([
+        'example.com/robots.txt' => Http::response("User-agent: *\nAllow: /", 200),
+        'example.com' => Http::response('ok', 200)
+    ]);
+
+    $website = Website::create(['domain'=>'example.com','base_url'=>'https://example.com']);
+    $agent = UserAgent::create([
+        'name'=>'GPTBot',
+        'user_agent_string'=>'GPTBot/1.0',
+        'user_agent_hash'=>hash('sha256','GPTBot/1.0'),
+        'type'=>'ai_bot',
+        'category'=>'good_bot'
+    ]);
+
+    CheckBotAccessibilityJob::dispatchSync($website, [$agent->id]);
+
+    expect($website->accessibilityResults()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- add migrations and models for websites, user agents, and results
- implement BotAccessibilityService with simple robots.txt and firewall checks
- add job and controller endpoints for checking websites
- seed a few AI user agents
- create Vue 3 page and Pinia store for managing websites
- add feature test skeleton

## Testing
- `php artisan test --testsuite Feature` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_b_688a3c36b2c483238816dac229d98fec