### PR TITLE
Add campaign-scoped job status tracking

### DIFF
--- a/app/Http/Controllers/JobStatusController.php
+++ b/app/Http/Controllers/JobStatusController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\JobStatus;
 use App\Models\Prompt;
+use App\Models\Campaign;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Bus;
 use App\Models\Team;
@@ -16,13 +17,15 @@ class JobStatusController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getTeamJobs(Request $request, Team $team)
+    public function getTeamJobs(Request $request, Team $team, ?Campaign $campaign = null)
     {
-        $teamId = $team->id;
+        $query = JobStatus::where('team_id', $team->id);
 
-        // Get job statuses for this team
-        $jobStatuses = JobStatus::where('team_id', $teamId)
-            ->orderBy('created_at', 'desc')
+        if ($campaign) {
+            $query->where('campaign_id', $campaign->id);
+        }
+
+        $jobStatuses = $query->orderBy('created_at', 'desc')
             ->limit(150)
             ->get();
 
@@ -32,13 +35,16 @@ class JobStatusController extends Controller
     /**
      * Cancel all pending jobs for the current team.
      */
-    public function cancelTeamJobs(Request $request, Team $team)
+    public function cancelTeamJobs(Request $request, Team $team, ?Campaign $campaign = null)
     {
-        $teamId = $team->id;
+        $query = JobStatus::where('team_id', $team->id)
+            ->where('status', 'pending');
 
-        $pendingJobs = JobStatus::where('team_id', $teamId)
-            ->where('status', 'pending')
-            ->get();
+        if ($campaign) {
+            $query->where('campaign_id', $campaign->id);
+        }
+
+        $pendingJobs = $query->get();
 
         $batchIds = $pendingJobs->pluck('job_batch_id')->filter()->unique();
 
@@ -46,9 +52,16 @@ class JobStatusController extends Controller
             Bus::findBatch($batchId)?->cancel();
         }
 
-        JobStatus::where('team_id', $teamId)
-            ->where('status', 'pending')
-            ->update(['status' => 'cancelled']);
+        if ($campaign) {
+            JobStatus::where('team_id', $team->id)
+                ->where('campaign_id', $campaign->id)
+                ->where('status', 'pending')
+                ->update(['status' => 'cancelled']);
+        } else {
+            JobStatus::where('team_id', $team->id)
+                ->where('status', 'pending')
+                ->update(['status' => 'cancelled']);
+        }
 
         return response()->json(['message' => 'Jobs cancelled']);
     }

--- a/app/Jobs/CheckTermInPastResponsesJob.php
+++ b/app/Jobs/CheckTermInPastResponsesJob.php
@@ -33,10 +33,11 @@ class CheckTermInPastResponsesJob extends TrackableJob
 	 * @param  \App\Models\Term  $term
 	 * @return void
 	 */
-	public function __construct(Term $term)
-	{
-		$this->term = $term;
-	}
+       public function __construct(Term $term)
+       {
+                $this->term = $term;
+                $this->campaignId = $term->organization->campaign_id ?? null;
+       }
 
 	/**
 	 * Execute the job.

--- a/app/Jobs/FindCompetitorsInResponseJob.php
+++ b/app/Jobs/FindCompetitorsInResponseJob.php
@@ -42,10 +42,11 @@ class FindCompetitorsInResponseJob extends TrackableJob
 	 * @param  \App\Models\Prompt  $prompt
 	 * @return void
 	 */
-	public function __construct(Prompt $prompt)
-	{
-		$this->prompt = $prompt;
-	}
+       public function __construct(Prompt $prompt)
+       {
+                $this->prompt = $prompt;
+                $this->campaignId = $prompt->campaign_id;
+       }
 
 	/**
 	 * Execute the job.

--- a/app/Jobs/GenerateCampaignKeywordsJob.php
+++ b/app/Jobs/GenerateCampaignKeywordsJob.php
@@ -41,10 +41,11 @@ class GenerateCampaignKeywordsJob extends TrackableJob
 	 * @param \App\Models\Campaign $campaign
 	 * @return void
 	 */
-	public function __construct(Campaign $campaign)
-	{
-		$this->campaign = $campaign;
-	}
+        public function __construct(Campaign $campaign)
+        {
+                $this->campaign = $campaign;
+                $this->campaignId = $campaign->id;
+        }
 
 	/**
 	 * Execute the job.

--- a/app/Jobs/GeneratePrompt.php
+++ b/app/Jobs/GeneratePrompt.php
@@ -55,12 +55,13 @@ class GeneratePrompt extends TrackableJob
 	 * @param  string  $keyword
 	 * @return void
 	 */
-	public function __construct(Campaign $campaign, Organization $organization, string $keyword)
-	{
-		$this->campaign = $campaign;
-		$this->organization = $organization;
-		$this->keyword = $keyword;
-	}
+       public function __construct(Campaign $campaign, Organization $organization, string $keyword)
+       {
+               $this->campaign = $campaign;
+                $this->campaignId = $campaign->id;
+               $this->organization = $organization;
+               $this->keyword = $keyword;
+       }
 
 	/**
 	 * Execute the job.

--- a/app/Jobs/TrackableJob.php
+++ b/app/Jobs/TrackableJob.php
@@ -19,7 +19,14 @@ abstract class TrackableJob implements ShouldQueue
 	 *
 	 * @var string
 	 */
-	protected $jobStatusId;
+    protected $jobStatusId;
+
+    /**
+     * The campaign ID if applicable.
+     *
+     * @var int|null
+     */
+    protected $campaignId;
 
 	/**
 	 * Set the job status ID.
@@ -79,13 +86,14 @@ abstract class TrackableJob implements ShouldQueue
 	 *
 	 * @return void
 	 */
-	protected function markJobAsStarted($output = null)
-	{
-		$this->updateJobStatus([
-			'status' => 'processing',
-			'output' => is_string($output) ? $output : json_encode($output),
-		]);
-	}
+    protected function markJobAsStarted($output = null)
+    {
+            $this->updateJobStatus([
+                    'status' => 'processing',
+                    'output' => is_string($output) ? $output : json_encode($output),
+                    'campaign_id' => $this->campaignId ?? $this->model->campaign_id ?? null,
+            ]);
+    }
 
 	/**
 	 * Mark the job as completed.
@@ -123,7 +131,7 @@ abstract class TrackableJob implements ShouldQueue
 	 * @param string|null $message
 	 * @return void
 	 */
-	protected function updateJobProgress(int $progress, string $message = null)
+        protected function updateJobProgress(int $progress, ?string $message = null)
 	{
 		$data = ['progress' => $progress];
 

--- a/app/Models/JobStatus.php
+++ b/app/Models/JobStatus.php
@@ -6,21 +6,23 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Traits\BelongsToTeam;
+use App\Models\Campaign;
 
 class JobStatus extends Model
 {
 	use Prunable, HasFactory, BelongsToTeam;
 
-	protected $fillable = [
-		'job_id',
-		'job_class',
-		'job_batch_id',
-		'status',
-		'output',
-		'error',
-		'progress',
-		'team_id',
-	];
+        protected $fillable = [
+                'job_id',
+                'job_class',
+                'job_batch_id',
+                'status',
+                'output',
+                'error',
+                'progress',
+                'team_id',
+                'campaign_id',
+        ];
 
 	/**
 	 * Get the prunable model query.
@@ -36,10 +38,18 @@ class JobStatus extends Model
 	/**
 	 * Get the owning trackable model.
 	 */
-	public function trackable()
-	{
-		return $this->morphTo();
-	}
+        public function trackable()
+        {
+                return $this->morphTo();
+        }
+
+        /**
+         * Get the campaign associated with the job.
+         */
+        public function campaign()
+        {
+                return $this->belongsTo(Campaign::class);
+        }
 
 	/**
 	 * Scope a query to only include pending jobs.

--- a/app/Services/JobDispatcherService.php
+++ b/app/Services/JobDispatcherService.php
@@ -17,10 +17,14 @@ class JobDispatcherService
 	 * @param mixed $job
 	 * @return void
 	 */
-	public function dispatch(Model $model, $job)
-	{
-		// Create a job status record and get the ID
-		$jobStatus = $model->trackJob($job);
+        public function dispatch(Model $model, $job, $campaignId = null)
+        {
+                if (!$campaignId && method_exists($model, 'campaign')) {
+                        $campaignId = $model->campaign_id;
+                }
+
+                // Create a job status record and get the ID
+                $jobStatus = $model->trackJob($job, null, $campaignId);
 
 		// Attach the job status ID to the job
 		$job->withJobStatus($jobStatus->job_id);

--- a/app/Traits/HasJobStatus.php
+++ b/app/Traits/HasJobStatus.php
@@ -36,19 +36,24 @@ trait HasJobStatus
 	/**
 	 * Create a job status for a new job.
 	 */
-	public function trackJob($job, $batchId = null)
-	{
-		// Generate a UUID for this job
-		$jobId = (string) Str::uuid();
+        public function trackJob($job, $batchId = null, $campaignId = null)
+        {
+                // Generate a UUID for this job
+                $jobId = (string) Str::uuid();
 
-		// Create a job status record
-		$status = $this->jobStatuses()->create([
-			'job_id' => $jobId,
-			'job_class' => get_class($job),
-			'job_batch_id' => $batchId,
-			'status' => 'pending',
-			'team_id' => $this->team_id,
-		]);
+                if (!$campaignId && method_exists($this, 'campaign')) {
+                        $campaignId = $this->campaign_id;
+                }
+
+                // Create a job status record
+                $status = $this->jobStatuses()->create([
+                        'job_id' => $jobId,
+                        'job_class' => get_class($job),
+                        'job_batch_id' => $batchId,
+                        'status' => 'pending',
+                        'team_id' => $this->team_id,
+                        'campaign_id' => $campaignId,
+                ]);
 
 		return $status;
 	}

--- a/database/migrations/2025_08_01_000000_add_campaign_id_to_job_statuses.php
+++ b/database/migrations/2025_08_01_000000_add_campaign_id_to_job_statuses.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('job_statuses', function (Blueprint $table) {
+            $table->unsignedBigInteger('campaign_id')->nullable()->after('team_id');
+            $table->foreign('campaign_id')->references('id')->on('campaigns')->onDelete('cascade');
+            $table->index(['team_id', 'campaign_id', 'status']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('job_statuses', function (Blueprint $table) {
+            $table->dropForeign(['campaign_id']);
+            $table->dropColumn('campaign_id');
+        });
+    }
+};

--- a/resources/js/components/jobs/ActiveJobsIndicator.vue
+++ b/resources/js/components/jobs/ActiveJobsIndicator.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { computed } from 'vue'
+import { useJobStatusStore } from '@/stores/jobStatusStore'
+import SpinnerIcon from '@/components/icons/SpinnerIcon.vue'
+
+const props = defineProps({
+        filterClass: {
+                type: String,
+                default: null
+        },
+        filterTrackableType: {
+                type: String,
+                default: null
+        },
+        filterTrackableId: {
+                type: Number,
+                default: null
+        },
+        showDetails: {
+                type: Boolean,
+                default: true
+        },
+        maxItems: {
+                type: Number,
+                default: 3
+        }
+})
+
+const jobStatusStore = useJobStatusStore()
+
+const activeJobs = computed(() => {
+        let jobs = jobStatusStore.activeJobs || []
+
+        if (props.filterClass) {
+                jobs = jobs.filter((job) => job.job_class.includes(props.filterClass))
+        }
+
+        if (props.filterTrackableType && props.filterTrackableId) {
+                jobs = jobs.filter((job) => job.trackable_type === props.filterTrackableType && job.trackable_id === props.filterTrackableId)
+        }
+
+        return jobs
+})
+
+const groupedJobs = computed(() => {
+        const grouped = {}
+        activeJobs.value.forEach((job) => {
+                const jobClass = job.job_class.split('\\').pop().replace(/Job$/, '')
+                if (!grouped[jobClass]) {
+                        grouped[jobClass] = []
+                }
+                grouped[jobClass].push(job)
+        })
+        return grouped
+})
+
+const totalActiveJobs = computed(() => activeJobs.value.length)
+</script>
+
+<template>
+        <div v-if="totalActiveJobs > 0" class="p-4 bg-green-50 border border-green-200 text-green-800 rounded-lg">
+                <div class="flex items-center gap-2">
+                        <SpinnerIcon class="animate-spin h-4 w-4 text-green-700" />
+                        <span class="font-medium">
+                                {{ totalActiveJobs }} {{ totalActiveJobs === 1 ? 'job' : 'jobs' }} running
+                        </span>
+                </div>
+
+                <div v-if="showDetails && Object.keys(groupedJobs).length > 0" class="mt-2 space-y-1">
+                        <div v-for="(jobs, jobClass) in groupedJobs" :key="jobClass" class="text-sm">
+                                <div v-for="(job, index) in jobs.slice(0, maxItems)" :key="job.job_id" class="pl-6">
+                                        {{ job.output || `Running ${jobClass}...` }}
+                                </div>
+                                <div v-if="jobs.length > maxItems" class="pl-6 text-green-600">
+                                        and {{ jobs.length - maxItems }} more...
+                                </div>
+                        </div>
+                </div>
+        </div>
+</template>

--- a/resources/js/components/prompts/PromptListItem.vue
+++ b/resources/js/components/prompts/PromptListItem.vue
@@ -29,16 +29,12 @@ const isRunMenuOpen = ref(false)
 
 const isLoading = computed(() => promptStore.loadingPromptIds.includes(props.prompt.id))
 
-const hasActiveRunPromptJob = computed(() => {
-	let jobs = (jobStatusStore.jobs || []).filter(
-		(job) =>
-			job.job_class.includes('RunPromptJob') &&
-			job.trackable_type === 'App\\Models\\Prompt' &&
-			job.trackable_id === props.prompt.id &&
-			(job.status === 'pending' || job.status === 'processing')
-	)
-
-	return jobs.length > 0
+const hasActiveJob = computed(() => {
+        return jobStatusStore.activeJobs.some(
+                (job) =>
+                        job.trackable_type === 'App\\Models\\Prompt' &&
+                        job.trackable_id === props.prompt.id
+        )
 })
 
 const formattedCreatedAt = computed(() => {
@@ -111,9 +107,9 @@ const createArticle = async () => {
 
 			<!-- Run prompt button -->
 			<div class="relative flex items-center">
-				<Button @click.stop="toggleRunMenu" :loading="hasActiveRunPromptJob" :disabled="isLoading" variant="outline" size="sm">
-					<span>{{ hasActiveRunPromptJob ? 'Running' : 'Run' }}</span>
-				</Button>
+                                <Button @click.stop="toggleRunMenu" :loading="hasActiveJob" :disabled="isLoading" variant="outline" size="sm">
+                                        <span>{{ hasActiveJob ? 'Running' : 'Run' }}</span>
+                                </Button>
 
 				<div
 					v-if="isRunMenuOpen"

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -4,6 +4,7 @@ import { onMounted, watch, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCampaignStore } from '@/stores/campaignStore'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
+import ActiveJobsIndicator from '@/components/jobs/ActiveJobsIndicator.vue'
 import { useOrganizationStore } from '@/stores/organizationStore'
 import VisibilityScore from '@/components/VisibilityScore.vue'
 import VisibilityChart from '@/components/VisibilityChart.vue'
@@ -31,13 +32,14 @@ const ownedOrg = computed(() => {
 })
 
 onMounted(async () => {
-	if (teamId.value) {
-		await campaignStore.fetchCampaigns(teamId.value)
-		if (campaignId.value) {
-			await campaignStore.switchCampaign(teamId.value, campaignId.value)
-			fetchVisibilityData()
-		}
-	}
+        if (teamId.value) {
+                await campaignStore.fetchCampaigns(teamId.value)
+                if (campaignId.value) {
+                        await campaignStore.switchCampaign(teamId.value, campaignId.value)
+                        fetchVisibilityData()
+                        await jobStatusStore.pollJobs(teamId.value, campaignId.value)
+                }
+        }
 })
 
 // Watch for job completions and refresh data
@@ -53,10 +55,11 @@ watch(
 )
 
 watch(campaignId, async (newId) => {
-	if (newId) {
-		await campaignStore.switchCampaign(teamId.value, newId)
-		fetchVisibilityData()
-	}
+        if (newId) {
+                await campaignStore.switchCampaign(teamId.value, newId)
+                fetchVisibilityData()
+                await jobStatusStore.pollJobs(teamId.value, newId)
+        }
 })
 
 const fetchVisibilityData = () => {
@@ -89,26 +92,7 @@ const deleteOrganization = async (organizationId) => {
 			<h1 class="text-2xl font-bold">Rankings</h1>
 			<CampaignSwitcher />
 		</div>
-		<!-- Jobs currently processing message -->
-		<div v-if="Object.keys(processingJobsByClass).length > 0" class="p-4 my-6 bg-green-50 border border-green-200 text-green-800 rounded-lg">
-			<div class="flex items-center gap-4 mb-2">
-				<span class="animate-spin h-4 w-4 border-t-2 border-b-2 border-green-700 rounded-full"></span>
-				<span class="font-semibold">Working</span>
-			</div>
-			<div class="pl-8 space-y-1">
-				<div v-for="(jobs, jobClass) in processingJobsByClass" :key="jobClass">
-					<div class="flex items-center justify-between">
-						<span>{{ jobs[0].output }}</span>
-					</div>
-					<div v-if="jobs.length > 1" class="flex items-center justify-between">
-						<span>{{ jobs[1].output }}</span>
-					</div>
-					<div v-if="jobs.length > 2" class="flex items-center justify-between">
-						<span>{{ jobs[2].output }}</span>
-					</div>
-				</div>
-			</div>
-		</div>
+               <ActiveJobsIndicator :show-details="true" :max-items="3" class="mt-6" />
 
 		<!-- Simplified Date Filter -->
 		<!-- <div class="mt-6">

--- a/resources/js/pages/organizations/Index.vue
+++ b/resources/js/pages/organizations/Index.vue
@@ -2,6 +2,7 @@
 import { onMounted, computed, watch } from 'vue'
 import { useOrganizationStore } from '@/stores/organizationStore'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
+import ActiveJobsIndicator from '@/components/jobs/ActiveJobsIndicator.vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useCampaignStore } from '@/stores/campaignStore'
 import moment from 'moment'
@@ -17,12 +18,10 @@ const route = useRoute()
 const teamId = computed(() => route.params.teamId)
 const campaignId = computed(() => route.params.campaignId)
 
-// Get active jobs related to competitors
-const activeCompetitorJobs = computed(() => {
-	return jobStatusStore.jobs.filter(
-		(job) => job.job_class.includes('FindCompetitorsInResponseJob') && (job.status === 'pending' || job.status === 'processing')
-	)
-})
+const activeCompetitorJobs = computed(() =>
+        jobStatusStore.activeJobs.filter((job) => job.job_class.includes('FindCompetitorsInResponseJob'))
+)
+
 
 // Watch for competitor job completions
 watch(
@@ -51,19 +50,20 @@ const isNewOrganization = (createdAt) => {
 }
 
 onMounted(async () => {
-	await campaignStore.fetchCampaigns(teamId.value)
-	if (campaignId.value) {
-		await campaignStore.switchCampaign(teamId.value, campaignId.value)
-	}
-	await organizationStore.fetchOrganizations(teamId.value, campaignId.value)
-	await jobStatusStore.pollTeamJobs(teamId.value)
+        await campaignStore.fetchCampaigns(teamId.value)
+        if (campaignId.value) {
+                await campaignStore.switchCampaign(teamId.value, campaignId.value)
+        }
+        await organizationStore.fetchOrganizations(teamId.value, campaignId.value)
+        await jobStatusStore.pollJobs(teamId.value, campaignId.value)
 })
 
 watch(campaignId, async (newId) => {
-	if (newId) {
-		await campaignStore.switchCampaign(teamId.value, newId)
-		await organizationStore.fetchOrganizations(teamId.value, newId)
-	}
+        if (newId) {
+                await campaignStore.switchCampaign(teamId.value, newId)
+                await organizationStore.fetchOrganizations(teamId.value, newId)
+                await jobStatusStore.pollJobs(teamId.value, newId)
+        }
 })
 </script>
 
@@ -77,13 +77,7 @@ watch(campaignId, async (newId) => {
 			<CampaignSwitcher />
 		</div>
 
-		<!-- Active jobs message -->
-		<div v-if="activeCompetitorJobs.length > 0" class="p-4 mt-4 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2">
-			<span class="animate-spin h-4 w-4 mr-2 border-t-2 border-b-2 border-green-700 rounded-full"></span>
-			<span>
-				Looking for new competitors in {{ activeCompetitorJobs.length }} prompt {{ activeCompetitorJobs.length === 1 ? 'response' : 'responses' }}.
-			</span>
-		</div>
+                <ActiveJobsIndicator filter-class="FindCompetitorsInResponseJob" :show-details="true" class="mt-4" />
 
 		<!-- Loading state -->
 		<div v-if="organizationStore.isLoading" class="flex justify-center py-8">

--- a/resources/js/pages/prompts/Index.vue
+++ b/resources/js/pages/prompts/Index.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { useCampaignStore } from '@/stores/campaignStore'
 import { usePromptStore } from '@/stores/promptStore'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
+import ActiveJobsIndicator from '@/components/jobs/ActiveJobsIndicator.vue'
 import { useOrganizationStore } from '@/stores/organizationStore'
 import CampaignSwitcher from '@/components/campaigns/CampaignSwitcher.vue'
 import PromptDetailSheet from '@/components/prompts/PromptDetailSheet.vue'
@@ -43,35 +44,17 @@ const sortOption = ref('default') // Default sort option
 // Jobs in progress by job class
 const processingJobsByClass = computed(() => jobStatusStore.processingJobsByClass)
 
-// Track active prompt jobs
-const activePromptJobs = computed(() => {
-	const promptJobClasses = ['GenerateCampaignKeywordsJob', 'GeneratePrompt', 'RunPromptJob', 'FindCompetitorsInResponseJob']
-	return (jobStatusStore.jobs || []).filter((job) => {
-		return promptJobClasses.some((className) => job.job_class.includes(className)) && (job.status === 'pending' || job.status === 'processing')
-	})
-})
 
 onMounted(async () => {
-	await campaignStore.fetchCampaigns(teamId.value)
-	if (campaignId.value) {
-		await campaignStore.switchCampaign(teamId.value, campaignId.value)
-	}
-	await promptStore.fetchPrompts(teamId.value, campaignId.value)
-	await organizationStore.fetchVisibilityMetrics(teamId.value, campaignId.value)
+        await campaignStore.fetchCampaigns(teamId.value)
+        if (campaignId.value) {
+                await campaignStore.switchCampaign(teamId.value, campaignId.value)
+        }
+        await promptStore.fetchPrompts(teamId.value, campaignId.value)
+        await organizationStore.fetchVisibilityMetrics(teamId.value, campaignId.value)
+        await jobStatusStore.pollJobs(teamId.value, campaignId.value)
 })
 
-watch(
-	activePromptJobs,
-	(newJobs, oldJobs) => {
-		if (oldJobs.length > newJobs.length || newJobs.length === 0) {
-			// At least one job completed, or all jobs are done
-            console.log('Jobs completed, refreshing prompts and visibility metrics')
-			promptStore.fetchPrompts(teamId.value, campaignId.value)
-            organizationStore.fetchVisibilityMetrics(teamId.value, campaignId.value)
-		}
-	},
-	{ deep: true }
-)
 
 // Watch for job completions and refresh data
 // watch(
@@ -85,11 +68,12 @@ watch(
 // )
 
 watch(campaignId, async (newId) => {
-	if (newId) {
-		await campaignStore.switchCampaign(teamId.value, newId)
-		await promptStore.fetchPrompts(teamId.value, newId)
-		await organizationStore.fetchVisibilityMetrics(teamId.value, newId)
-	}
+        if (newId) {
+                await campaignStore.switchCampaign(teamId.value, newId)
+                await promptStore.fetchPrompts(teamId.value, newId)
+                await organizationStore.fetchVisibilityMetrics(teamId.value, newId)
+                await jobStatusStore.pollJobs(teamId.value, newId)
+        }
 })
 
 // Track prompt deletion
@@ -98,14 +82,14 @@ const promptToDelete = ref(null)
 const showDeleteConfirmation = ref(false)
 
 const runPrompt = async (id, count = 1) => {
-	await promptStore.runPrompt(id, count)
-	await jobStatusStore.pollTeamJobs(teamId.value)
+        await promptStore.runPrompt(id, count)
+        await jobStatusStore.pollJobs(teamId.value, campaignId.value)
 }
 
 const runAllPrompts = async (count = 1) => {
 	try {
-		await promptStore.runAllPrompts(teamId.value, campaignId.value, count)
-		await jobStatusStore.pollTeamJobs(teamId.value)
+                await promptStore.runAllPrompts(teamId.value, campaignId.value, count)
+                await jobStatusStore.pollJobs(teamId.value, campaignId.value)
 	} catch (error) {
 		console.error('Error running all prompts:', error)
 	}
@@ -206,17 +190,7 @@ const handleDateRangeChange = (dateRange) => {
 						/>
 					</div>
 
-					<!-- Active jobs message -->
-					<div
-						v-if="activePromptJobs.length > 0"
-						class="p-4 mb-4 bg-green-50 border border-green-200 text-green-800 rounded-lg flex items-center gap-2"
-					>
-						<span class="animate-spin h-4 w-4 mr-2 border-t-2 border-b-2 border-green-700 rounded-full"></span>
-						<span>
-							{{ activePromptJobs.length }}
-							{{ activePromptJobs.length === 1 ? 'prompt related job is being run' : 'prompt related jobs are being run' }}
-						</span>
-					</div>
+                                        <ActiveJobsIndicator filter-class="Prompt" :show-details="true" class="mb-4" />
 
 					<!-- Jobs currently processing message -->
 					<!-- <div v-if="Object.keys(processingJobsByClass).length > 0" class="p-4 mb-6 bg-green-50 border border-green-200 text-green-800 rounded-lg">
@@ -252,7 +226,7 @@ const handleDateRangeChange = (dateRange) => {
 						/>
 					</div>
 
-					<div v-else-if="activePromptJobs.length <= 0" class="text-center py-4 text-neutral-500 text-sm">No prompts data available</div>
+                                        <div v-else class="text-center py-4 text-neutral-500 text-sm">No prompts data available</div>
 				</div>
 			</div>
 		</div>

--- a/resources/js/stores/jobStatusStore.js
+++ b/resources/js/stores/jobStatusStore.js
@@ -4,10 +4,11 @@ import api from '@/services/api'
 
 export const useJobStatusStore = defineStore('jobStatus', () => {
 	// State
-	const jobs = ref([])
-	const batch = ref(null)
-	const loading = ref(false)
-	let refreshTimer = ref(null)
+       const jobs = ref([])
+       const loading = ref(false)
+       let refreshTimer = ref(null)
+       const currentTeamId = ref(null)
+       const currentCampaignId = ref(null)
 
 	// Getters
 	const activeJobs = computed(() => (jobs.value ? jobs.value.filter((job) => job.status === 'pending' || job.status === 'processing') : []))
@@ -43,61 +44,73 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 	})
 
 	// Actions
-	async function pollTeamJobs(teamId) {
-		await fetchTeamJobs(teamId)
-		startAutoRefresh(teamId, 1500)
-	}
+       async function pollJobs(teamId, campaignId = null) {
+               currentTeamId.value = teamId
+               currentCampaignId.value = campaignId
+               await fetchJobs()
+               startAutoRefresh()
+       }
 
-	async function fetchTeamJobs(teamId) {
-		console.log('Fetching team jobs...')
-		loading.value = true
+       async function fetchJobs() {
+               if (!currentTeamId.value) return
 
-		try {
-			const response = await api.get(`/teams/${teamId}/jobs`)
-			// console.log('jobs response', response)
-			jobs.value = response
-			return jobs.value
-		} catch (err) {
-			console.error('Error loading team jobs:', err)
-			throw err
-		} finally {
-			loading.value = false
-		}
-	}
+               loading.value = true
 
-	async function cancelTeamJobs(teamId) {
-		try {
-			await api.post(`/teams/${teamId}/jobs/cancel`)
-			await fetchTeamJobs(teamId)
-		} catch (err) {
-			console.error('Error cancelling jobs:', err)
-			throw err
-		}
-	}
+               try {
+                       const endpoint = currentCampaignId.value
+                               ? `/teams/${currentTeamId.value}/campaigns/${currentCampaignId.value}/jobs`
+                               : `/teams/${currentTeamId.value}/jobs`
+
+                       const response = await api.get(endpoint)
+                       jobs.value = response
+                       return jobs.value
+               } catch (err) {
+                       console.error('Error loading jobs:', err)
+                       throw err
+               } finally {
+                       loading.value = false
+               }
+       }
+
+       async function cancelJobs() {
+               if (!currentTeamId.value) return
+
+               try {
+                       const endpoint = currentCampaignId.value
+                               ? `/teams/${currentTeamId.value}/campaigns/${currentCampaignId.value}/jobs/cancel`
+                               : `/teams/${currentTeamId.value}/jobs/cancel`
+
+                       await api.post(endpoint)
+                       await fetchJobs()
+               } catch (err) {
+                       console.error('Error cancelling jobs:', err)
+                       throw err
+               }
+       }
 
 	function hasActiveJobs() {
 		return Array.isArray(jobs.value) && jobs.value.some((job) => job.status === 'pending' || job.status === 'processing')
 	}
 
-	function startAutoRefresh(teamId, interval = 2000) {
-		stopAutoRefresh()
-		let pollsAfterCompletion = 0
-		const maxPollsAfterCompletion = 3 // Poll 3 more times after completion
+       function startAutoRefresh(interval = 2000) {
+               stopAutoRefresh()
+               let pollsAfterCompletion = 0
+               const maxPollsAfterCompletion = 3 // Poll 3 more times after completion
 
-		refreshTimer.value = setInterval(() => {
-			if (hasActiveJobs()) {
-				fetchTeamJobs(teamId)
-				pollsAfterCompletion = 0 // Reset counter when active jobs exist
-			} else if (pollsAfterCompletion < maxPollsAfterCompletion) {
-				// Continue polling for a few cycles after completion to catch final updates
-				fetchTeamJobs(teamId)
-				pollsAfterCompletion++
-			} else {
-				// Stop polling after we've checked enough times post-completion
-				stopAutoRefresh()
-			}
-		}, interval)
-	}
+               refreshTimer.value = setInterval(() => {
+                       if (hasActiveJobs()) {
+                               fetchJobs()
+                               pollsAfterCompletion = 0 // Reset counter when active jobs exist
+                       } else if (pollsAfterCompletion < maxPollsAfterCompletion) {
+                               // Continue polling for a few cycles after completion to catch final updates
+                               fetchJobs()
+                               pollsAfterCompletion++
+                       } else {
+                               // Stop polling after we've checked enough times post-completion
+                               stopAutoRefresh()
+                       }
+               }, interval)
+       }
 
 	function stopAutoRefresh() {
 		if (refreshTimer.value) {
@@ -110,18 +123,10 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		return jobs.value.find((job) => job.job_id === jobId)
 	}
 
-	function getBatchById(batchId) {
-		if (batch.value && batch.value.id === batchId) {
-			return batch.value
-		}
-		return null
-	}
-
-	return {
-		// State
-		jobs: computed(() => jobs.value),
-		batch: computed(() => batch.value),
-		loading,
+       return {
+               // State
+               jobs: computed(() => jobs.value),
+               loading,
 
 		// Getters
 		activeJobs,
@@ -131,13 +136,16 @@ export const useJobStatusStore = defineStore('jobStatus', () => {
 		completedJobsByClass,
 
 		// Actions
-		pollTeamJobs,
-		fetchTeamJobs,
-		hasActiveJobs,
-		startAutoRefresh,
-		stopAutoRefresh,
-		getJobById,
-		getBatchById,
-		cancelTeamJobs
-	}
+               pollJobs,
+               fetchJobs,
+               hasActiveJobs,
+               startAutoRefresh,
+               stopAutoRefresh,
+               getJobById,
+               cancelJobs,
+               // Backward compatibility
+               pollTeamJobs: pollJobs,
+               fetchTeamJobs: fetchJobs,
+               cancelTeamJobs: cancelJobs
+       }
 })

--- a/routes/api.php
+++ b/routes/api.php
@@ -103,8 +103,10 @@ Route::middleware('auth:sanctum')->group(function () {
 	Route::put('teams/{team}/members/{user}/role', [TeamController::class, 'updateMemberRole']);
 
 	// Job status routes
-	Route::get('teams/{team}/jobs', [JobStatusController::class, 'getTeamJobs']);
-	Route::post('teams/{team}/jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
+        Route::get('teams/{team}/jobs', [JobStatusController::class, 'getTeamJobs']);
+        Route::get('teams/{team}/campaigns/{campaign}/jobs', [JobStatusController::class, 'getTeamJobs']);
+        Route::post('teams/{team}/jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
+        Route::post('teams/{team}/campaigns/{campaign}/jobs/cancel', [JobStatusController::class, 'cancelTeamJobs']);
 
 	// Articles
 	Route::get('teams/{team}/campaigns/{campaign}/articles', [ArticleController::class, 'index']);

--- a/tests/Feature/Job/JobStatusControllerTest.php
+++ b/tests/Feature/Job/JobStatusControllerTest.php
@@ -2,61 +2,66 @@
 
 use App\Models\JobStatus;
 use App\Models\Team;
+use App\Models\Campaign;
 use Laravel\Sanctum\Sanctum;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
 it('returns job statuses for the authenticated team', function () {
-	$team = Team::factory()->create();
-	$user = $team->owner;
-	$user->current_team_id = $team->id;
-	$user->save();
-	Sanctum::actingAs($user);
+        $team = Team::factory()->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        $user = $team->owner;
+        $user->current_team_id = $team->id;
+        $user->save();
+        Sanctum::actingAs($user);
 
-	JobStatus::factory()->count(3)->for($team)->create();
-	$otherTeam = Team::factory()->create();
-	JobStatus::factory()->count(2)->for($otherTeam)->create();
+        JobStatus::factory()->count(3)->for($team)->state(['campaign_id' => $campaign->id])->create();
+        $otherTeam = Team::factory()->create();
+        JobStatus::factory()->count(2)->for($otherTeam)->create();
 
-	$response = $this->getJson("/api/teams/{$team->id}/jobs");
+        $response = $this->getJson("/api/teams/{$team->id}/campaigns/{$campaign->id}/jobs");
 
 	$response->assertStatus(200)
-		->assertJsonCount(3)
-		->assertJsonPath('0.team_id', $team->id)
-		->assertJsonPath('1.team_id', $team->id)
-		->assertJsonPath('2.team_id', $team->id);
+                ->assertJsonCount(3)
+                ->assertJsonPath('0.campaign_id', $campaign->id)
+                ->assertJsonPath('1.campaign_id', $campaign->id)
+                ->assertJsonPath('2.campaign_id', $campaign->id);
 });
 
 it('limits results to 150 in descending order', function () {
-	$team = Team::factory()->create();
-	$user = $team->owner;
-	$user->current_team_id = $team->id;
-	$user->save();
-	Sanctum::actingAs($user);
+        $team = Team::factory()->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        $user = $team->owner;
+        $user->current_team_id = $team->id;
+        $user->save();
+        Sanctum::actingAs($user);
 
-	$jobs = JobStatus::factory()->for($team)
-		->count(155)
-		->sequence(fn($sequence) => ['created_at' => now()->addSeconds($sequence->index)])
-		->create();
+        $jobs = JobStatus::factory()->for($team)
+                ->state(['campaign_id' => $campaign->id])
+                ->count(155)
+                ->sequence(fn($sequence) => ['created_at' => now()->addSeconds($sequence->index)])
+                ->create();
 
-	$response = $this->getJson("/api/teams/{$team->id}/jobs");
-	$response->assertStatus(200)
-		->assertJsonCount(150)
-		->assertJsonPath('0.id', $jobs->last()->id);
+        $response = $this->getJson("/api/teams/{$team->id}/campaigns/{$campaign->id}/jobs");
+        $response->assertStatus(200)
+                ->assertJsonCount(150)
+                ->assertJsonPath('0.id', $jobs->last()->id);
 });
 
-it('cancels pending jobs for the authenticated team', function () {
-	$team = Team::factory()->create();
-	$user = $team->owner;
-	$user->current_team_id = $team->id;
-	$user->save();
-	Sanctum::actingAs($user);
+it('cancels pending jobs for the authenticated team and campaign', function () {
+        $team = Team::factory()->create();
+        $campaign = Campaign::factory()->for($team)->create();
+        $user = $team->owner;
+        $user->current_team_id = $team->id;
+        $user->save();
+        Sanctum::actingAs($user);
 
-	JobStatus::factory()->count(2)->for($team)->state(['status' => 'pending'])->create();
+        JobStatus::factory()->count(2)->for($team)->state(['status' => 'pending', 'campaign_id' => $campaign->id])->create();
 
-	$response = $this->postJson("/api/teams/{$team->id}/jobs/cancel");
+        $response = $this->postJson("/api/teams/{$team->id}/campaigns/{$campaign->id}/jobs/cancel");
 
-	$response->assertStatus(200);
+        $response->assertStatus(200);
 
-	expect(JobStatus::where('team_id', $team->id)->where('status', 'cancelled')->count())->toBe(2);
+        expect(JobStatus::where('team_id', $team->id)->where('campaign_id', $campaign->id)->where('status', 'cancelled')->count())->toBe(2);
 });


### PR DESCRIPTION
## Summary
- add `campaign_id` to job_statuses table
- update JobStatus model, trait and controller for campaign filtering
- update dispatcher, jobs and TrackableJob for campaign awareness
- simplify job status polling via new `ActiveJobsIndicator` component
- update Dashboard, Prompts and Organizations pages to use new indicator
- extend jobStatusStore with campaign-scoped API calls
- update routes and tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_688d02aba34c8323a1bc0dc435c17c58