### PR TITLE
Add prompt-specific visibility chart

### DIFF
--- a/app/Http/Controllers/PromptVisibilityChartController.php
+++ b/app/Http/Controllers/PromptVisibilityChartController.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Prompt;
+use App\Models\Organization;
+use App\Models\Term;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class PromptVisibilityChartController extends Controller
+{
+    /**
+     * Get visibility data over time for a specific prompt
+     */
+    public function chartData(Request $request, Prompt $prompt)
+    {
+        $request->validate([
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date|after_or_equal:start_date',
+            'interval' => 'nullable|in:daily,weekly,monthly'
+        ]);
+
+        $teamId = $prompt->team_id;
+        $campaignId = $prompt->campaign_id;
+
+        // Handle date range
+        if (!$request->start_date || !$request->end_date) {
+            $firstResponse = $prompt->responses()->orderBy('created_at')->first();
+            $lastResponse = $prompt->responses()->orderBy('created_at', 'desc')->first();
+
+            if (!$firstResponse || !$lastResponse) {
+                return response()->json([
+                    'organizations' => [],
+                    'interval' => $request->input('interval', 'daily'),
+                    'start_date' => null,
+                    'end_date' => null
+                ]);
+            }
+
+            $startDate = Carbon::parse($firstResponse->created_at)->startOfDay();
+            $endDate = Carbon::parse($lastResponse->created_at)->endOfDay();
+        } else {
+            $startDate = Carbon::parse($request->start_date);
+            $endDate = Carbon::parse($request->end_date);
+        }
+
+        $interval = $request->input('interval', 'daily');
+
+        // Get the owned organization
+        $organizations = Organization::where('team_id', $teamId)
+            ->forCampaign($campaignId)
+            ->where('is_competitor', false)
+            ->get();
+
+        // Generate date intervals
+        $intervals = $this->generateIntervals($startDate, $endDate, $interval);
+
+        $chartData = [];
+
+        foreach ($organizations as $organization) {
+            $dataPoints = [];
+
+            // Get all term IDs for this organization
+            $termIds = Term::where('organization_id', $organization->id)
+                ->pluck('id')
+                ->toArray();
+
+            foreach ($intervals as $intervalData) {
+                $intervalStart = $intervalData['start'];
+                $intervalEnd = $intervalData['end'];
+
+                // Calculate visibility for this interval FOR THIS SPECIFIC PROMPT
+                $totalResponses = $prompt->responses()
+                    ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                    ->count();
+
+                $totalMentions = 0;
+                if (!empty($termIds) && $totalResponses > 0) {
+                    $totalMentions = $prompt->responses()
+                        ->whereHas('terms', function ($query) use ($termIds) {
+                            $query->whereIn('terms.id', $termIds);
+                        })
+                        ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                        ->count();
+                }
+
+                $visibility = $totalResponses > 0
+                    ? round(($totalMentions / $totalResponses) * 100, 2)
+                    : 0;
+
+                $dataPoints[] = [
+                    'date' => $intervalData['label'],
+                    'visibility' => $visibility,
+                    'mentions' => $totalMentions,
+                    'responses' => $totalResponses
+                ];
+            }
+
+            $chartData[] = [
+                'id' => $organization->id,
+                'name' => $organization->name ?? 'Your Organization',
+                'is_competitor' => false,
+                'color' => $organization->color ?? '#10B981',
+                'data' => $dataPoints
+            ];
+        }
+
+        return response()->json([
+            'organizations' => $chartData,
+            'interval' => $interval,
+            'start_date' => $startDate->format('Y-m-d'),
+            'end_date' => $endDate->format('Y-m-d')
+        ]);
+    }
+
+    /**
+     * Generate date intervals based on the selected interval type
+     */
+    private function generateIntervals(Carbon $startDate, Carbon $endDate, string $interval): array
+    {
+        // Copy the same logic from OrganizationVisibilityChartController
+        $intervals = [];
+        $current = $startDate->copy();
+
+        while ($current <= $endDate) {
+            switch ($interval) {
+                case 'daily':
+                    $intervalEnd = $current->copy()->endOfDay();
+                    $label = $current->format('M d');
+                    $next = $current->copy()->addDay();
+                    break;
+
+                case 'weekly':
+                    $intervalEnd = $current->copy()->endOfWeek();
+                    $label = $current->format('M d') . ' - ' . $intervalEnd->format('M d');
+                    $next = $current->copy()->addWeek();
+                    break;
+
+                case 'monthly':
+                    $intervalEnd = $current->copy()->endOfMonth();
+                    $label = $current->format('M Y');
+                    $next = $current->copy()->addMonth()->startOfMonth();
+                    break;
+
+                default:
+                    $intervalEnd = $current->copy()->endOfDay();
+                    $label = $current->format('M d');
+                    $next = $current->copy()->addDay();
+            }
+
+            if ($intervalEnd > $endDate) {
+                $intervalEnd = $endDate->copy()->endOfDay();
+            }
+
+            $intervals[] = [
+                'start' => $current->copy(),
+                'end' => $intervalEnd,
+                'label' => $label
+            ];
+
+            $current = $next;
+        }
+
+        return $intervals;
+    }
+}
+

--- a/resources/js/components/VisibilityChart.vue
+++ b/resources/js/components/VisibilityChart.vue
@@ -1,10 +1,10 @@
 <template>
-	<div class="bg-white rounded-lg p-6 border border-neutral-200 shadow-sm">
-		<div class="flex items-center justify-between mb-4">
-			<div class="flex items-center gap-2">
-				<h2 class="text-xl font-bold">Visibility Over Time</h2>
-				<div v-if="isLoading" class="animate-spin rounded-full size-4 border-b-2 border-neutral-800"></div>
-			</div>
+        <div class="bg-white rounded-lg p-6 border border-neutral-200 shadow-sm">
+                <div class="flex items-center justify-between mb-4">
+                        <div class="flex items-center gap-2">
+                                <h2 class="text-xl font-bold">{{ title }}</h2>
+                                <div v-if="isLoading" class="animate-spin rounded-full size-4 border-b-2 border-neutral-800"></div>
+                        </div>
 
 			<!-- Interval selector -->
 			<div class="relative">
@@ -55,14 +55,22 @@ import api from '@/services/api'
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue'
 
 const props = defineProps({
-	startDate: String,
-	endDate: String,
-	teamId: String,
-	campaignId: String,
-	defaultInterval: {
-		type: String,
-		default: 'monthly'
-	}
+        startDate: String,
+        endDate: String,
+        teamId: String,
+        campaignId: String,
+        promptId: {
+                type: [String, Number],
+                default: null
+        },
+        defaultInterval: {
+                type: String,
+                default: 'monthly'
+        },
+        title: {
+                type: String,
+                default: 'Visibility Over Time'
+        }
 })
 
 const organizationStore = useOrganizationStore()
@@ -95,52 +103,57 @@ const selectInterval = (value) => {
 let latestRequestId = 0
 
 const fetchChartData = async () => {
-	// Don't fetch if we're unmounting or missing required props
-	if (isUnmounting.value || !props.teamId || !props.campaignId) return
+        // Don't fetch if we're unmounting or missing required props
+        if (isUnmounting.value || !props.teamId || (!props.campaignId && !props.promptId)) return
 
-	isLoading.value = true
+        isLoading.value = true
 
-	try {
-		// Prevent multiple simultaneous requests with a more robust ID system
-		const currentRequestId = Date.now()
-		latestRequestId = currentRequestId
+        try {
+                const currentRequestId = Date.now()
+                latestRequestId = currentRequestId
 
-		const params = new URLSearchParams({
-			start_date: props.startDate,
-			end_date: props.endDate,
-			interval: selectedInterval.value
-		})
+                const params = new URLSearchParams({
+                        start_date: props.startDate,
+                        end_date: props.endDate,
+                        interval: selectedInterval.value
+                })
 
-		// Always include the owned organization
-		const ownedOrg = organizationStore.visibilityMetrics.find((org) => !org.is_competitor)
-		if (ownedOrg) {
-			params.append('organization_ids[]', ownedOrg.id)
-		}
+                // Determine which endpoint to use
+                let endpoint
+                if (props.promptId) {
+                        // Prompt-specific visibility
+                        endpoint = `/prompts/${props.promptId}/visibility-chart`
+                } else {
+                        // Overall campaign visibility
+                        endpoint = `/teams/${props.teamId}/campaigns/${props.campaignId}/organization-visibility/chart`
 
-		const response = await api.get(`/teams/${props.teamId}/campaigns/${props.campaignId}/organization-visibility/chart?${params}`)
+                        // For campaign view, include owned org
+                        const ownedOrg = organizationStore.visibilityMetrics.find((org) => !org.is_competitor)
+                        if (ownedOrg) {
+                                params.append('organization_ids[]', ownedOrg.id)
+                        }
+                }
 
-		// Check if a newer request has come in while we were waiting or if unmounting
-		if (currentRequestId !== latestRequestId || isUnmounting.value) {
-			return // Abandon this update as it's stale or component is unmounting
-		}
+                const response = await api.get(`${endpoint}?${params}`)
 
-		chartData.value = response.organizations || []
+                if (currentRequestId !== latestRequestId || isUnmounting.value) {
+                        return
+                }
 
-		// If component is unmounting, don't proceed with chart update
-		if (isUnmounting.value) return
+                chartData.value = response.organizations || []
 
-		// Ensure DOM is updated before updating chart
-		await nextTick()
+                if (isUnmounting.value) return
 
-		// Final check before updating chart
-		if (!isUnmounting.value && chartContainer.value) {
-			updateChart()
-		}
-	} catch (error) {
-		console.error('Error fetching chart data:', error)
-	} finally {
-		isLoading.value = false
-	}
+                await nextTick()
+
+                if (!isUnmounting.value && chartContainer.value) {
+                        updateChart()
+                }
+        } catch (error) {
+                console.error('Error fetching chart data:', error)
+        } finally {
+                isLoading.value = false
+        }
 }
 
 // Flag to track if component is being unmounted

--- a/resources/js/components/prompts/PromptDetailSheet.vue
+++ b/resources/js/components/prompts/PromptDetailSheet.vue
@@ -3,6 +3,8 @@ import { computed, watch, onMounted, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { usePromptStore } from '@/stores/promptStore'
 import { useArticleStore } from '@/stores/articleStore'
+import VisibilityChart from '@/components/VisibilityChart.vue'
+import { useOrganizationStore } from '@/stores/organizationStore'
 import api from '@/services/api.js'
 import Sheet from '@/components/ui/Sheet.vue'
 import Button from '@/components/ui/Button.vue'
@@ -30,7 +32,11 @@ const emit = defineEmits(['close'])
 
 const promptStore = usePromptStore()
 const articleStore = useArticleStore()
+const organizationStore = useOrganizationStore()
 const isCopied = ref(false)
+
+// Add a ref to control chart visibility
+const showChart = ref(false)
 
 const promptDetails = computed(() => {
 	return promptStore.selectedPromptDetails
@@ -63,10 +69,12 @@ watch(
 
 // Fetch prompt details when component mounts or promptId changes
 const fetchDetails = async () => {
-	if (props.promptId) {
-		await promptStore.showPrompt(props.promptId)
-		await promptStore.getPromptResponses(props.promptId)
-	}
+        if (props.promptId) {
+                showChart.value = false // Hide chart while loading
+                await promptStore.showPrompt(props.promptId)
+                await promptStore.getPromptResponses(props.promptId)
+                showChart.value = true // Show chart after data is loaded
+        }
 }
 
 // Method to highlight terms in response content
@@ -150,8 +158,30 @@ watch(() => props.promptId, fetchDetails)
 					</div> -->
 				</div>
 
-				<!-- Articles section -->
-				<div class="mt-6">
+                                <!-- Visibility Chart for this Prompt -->
+                                <div v-if="showChart && promptDetails" class="mt-6">
+                                        <VisibilityChart
+                                                :prompt-id="props.promptId"
+                                                :team-id="teamId"
+                                                :campaign-id="campaignId"
+                                                :start-date="organizationStore.currentDateRange.startDate"
+                                                :end-date="organizationStore.currentDateRange.endDate"
+                                                :title="`Visibility for: ${promptDetails.content?.substring(0, 50)}${promptDetails.content?.length > 50 ? '...' : ''}`"
+                                                :default-interval="'daily'"
+                                        />
+                                </div>
+
+                                <!-- Loading state for chart -->
+                                <div v-if="!showChart && promptStore.isLoadingDetails" class="mt-6 bg-white rounded-lg p-6 border border-neutral-200 shadow-sm">
+                                        <div class="flex items-center gap-2 mb-4">
+                                                <h2 class="text-xl font-bold">Loading Visibility Chart...</h2>
+                                                <div class="animate-spin rounded-full size-4 border-b-2 border-neutral-800"></div>
+                                        </div>
+                                        <div class="h-[400px] bg-neutral-100 animate-pulse rounded"></div>
+                                </div>
+
+                                <!-- Articles section -->
+                                <div class="mt-6">
 					<div class="flex items-center justify-between gap-6 mb-6">
 						<div>
 							<h3 class="text-lg font-medium text-neutral-800 mb-1">Articles</h3>

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\PromptResponsesController;
 use App\Http\Controllers\PromptGeneratorController;
 use App\Http\Controllers\PromptExportController;
 use App\Http\Controllers\PromptController;
+use App\Http\Controllers\PromptVisibilityChartController;
 use App\Http\Controllers\OrganizationVisibilityController;
 use App\Http\Controllers\OrganizationVisibilityChartController;
 use App\Http\Controllers\OrganizationSearchController;
@@ -94,6 +95,9 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Prompt export
     Route::get('prompts/{prompt}/export', [PromptExportController::class, 'show']);
+
+    // Prompt visibility chart
+    Route::get('prompts/{prompt}/visibility-chart', [PromptVisibilityChartController::class, 'chartData']);
 
     // Running prompts
     Route::post('prompts/{prompt}/run', [PromptRunController::class, 'store']);


### PR DESCRIPTION
## Summary
- compute prompt visibility over time via new `PromptVisibilityChartController`
- extend `VisibilityChart` to display prompt data or campaign-level data
- render prompt visibility chart on `PromptDetailSheet`

## Testing
- `npm run build`
- `composer install` *(fails: Failed to download php-http/discovery from dist: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_6894efd83ed483239267c144db9fb94b