### PR TITLE
Use route parameter as team source of truth

### DIFF
--- a/resources/js/components/AppNav.vue
+++ b/resources/js/components/AppNav.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useTeamStore } from '@/stores/teamStore'
 import { useCampaignStore } from '@/stores/campaignStore'
@@ -54,20 +54,26 @@ const logout = async () => {
 }
 
 const switchTeam = async (teamId) => {
-	try {
-		const response = await teamStore.switchTeam(teamId)
-		window.location.href = `/teams/${teamId}/campaigns/${response.default_campaign.id}`
-	} catch (error) {
-		console.error('Error switching team:', error)
-	}
+        try {
+                const response = await teamStore.switchTeam(teamId)
+                window.location.href = `/teams/${teamId}/campaigns/${response.default_campaign.id}`
+        } catch (error) {
+                console.error('Error switching team:', error)
+        }
 }
 
-onMounted(async () => {
-	if (route.params.teamId) {
-		jobStatusStore.pollTeamJobs(route.params.teamId)
-	}
-	isTeamDropdownOpen.value = false
-})
+watch(
+        () => route.params.teamId,
+        async (newTeamId) => {
+                if (newTeamId) {
+                        await teamStore.fetchTeam(newTeamId)
+                        jobStatusStore.pollTeamJobs(newTeamId)
+                } else {
+                        teamStore.currentTeam = null
+                }
+        },
+        { immediate: true }
+)
 </script>
 
 <template>

--- a/resources/js/components/jobs/JobStatusSheet.vue
+++ b/resources/js/components/jobs/JobStatusSheet.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import Sheet from '@/components/ui/Sheet.vue'
 import Button from '@/components/ui/Button.vue'
 import JobStatusList from '@/components/jobs/JobStatusList.vue'
 import SpinnerIcon from '@/components/icons/SpinnerIcon.vue'
 import { useJobStatusStore } from '@/stores/jobStatusStore'
-import { useTeamStore } from '@/stores/teamStore'
 
 const props = defineProps({
 	isOpen: {
@@ -21,15 +21,15 @@ const closeSheet = () => {
 }
 
 const jobStatusStore = useJobStatusStore()
-const teamStore = useTeamStore()
+const route = useRoute()
+const teamId = computed(() => route.params.teamId)
 const isCancelling = ref(false)
 
 async function cancelJobs() {
-        const teamId = teamStore.currentTeam?.id
-        if (!teamId) return
+        if (!teamId.value) return
         isCancelling.value = true
         try {
-                await jobStatusStore.cancelTeamJobs(teamId)
+                await jobStatusStore.cancelTeamJobs(teamId.value)
         } finally {
                 isCancelling.value = false
         }

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -25,8 +25,8 @@ const login = async () => {
 			password: password.value
 		})
 
-		// Fetch teams immediately after login to ensure currentTeam is set
-		await teamStore.fetchTeams()
+                // Load teams after login
+                await teamStore.fetchTeams()
 
 		// Fetch campaigns for the current team if available
 		const user = JSON.parse(localStorage.getItem('user'))

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -41,8 +41,8 @@ const register = async () => {
 
 			await auth.register(registrationData)
 
-			// Fetch teams immediately after login to ensure currentTeam is set
-			await teamStore.fetchTeams()
+                        // Load teams after login
+                        await teamStore.fetchTeams()
 
 			router.push('/')
 		} else {

--- a/resources/js/pages/teams/Show.vue
+++ b/resources/js/pages/teams/Show.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useTeamStore } from '@/stores/teamStore'
 import auth from '@/services/auth'
@@ -26,10 +26,17 @@ const copiedInviteUrls = ref({})
 const activeDropdown = ref(null)
 
 onMounted(async () => {
-	await loadTeam()
-	// Close dropdown when clicking outside
-	document.addEventListener('click', handleClickOutside)
+        await loadTeam()
+        // Close dropdown when clicking outside
+        document.addEventListener('click', handleClickOutside)
 })
+
+watch(
+        () => route.params.teamId,
+        async () => {
+                await loadTeam()
+        }
+)
 
 const handleClickOutside = (event) => {
 	if (!event.target.closest('.dropdown-container')) {

--- a/resources/js/stores/teamStore.js
+++ b/resources/js/stores/teamStore.js
@@ -13,33 +13,21 @@ export const useTeamStore = defineStore('team', {
 	}),
 
 	actions: {
-		async fetchTeams() {
-			console.log('Fetching teams...')
-			this.isLoading = true
+                async fetchTeams() {
+                        console.log('Fetching teams...')
+                        this.isLoading = true
 
-			try {
-				const response = await api.get('/teams')
-				this.ownedTeams = response.ownedTeams
-				this.joinedTeams = response.joinedTeams
-				this.pendingInvitations = response.pendingInvitations
-
-				// Set current team based on user's current_team_id
-				const user = JSON.parse(localStorage.getItem('user'))
-				if (user && user.current_team_id) {
-					this.currentTeam = this.getCurrentTeam(
-						{
-							ownedTeams: this.ownedTeams,
-							joinedTeams: this.joinedTeams
-						},
-						user
-					)
-				}
-			} catch (error) {
-				console.error('Error fetching teams:', error)
-			} finally {
-				this.isLoading = false
-			}
-		},
+                        try {
+                                const response = await api.get('/teams')
+                                this.ownedTeams = response.ownedTeams
+                                this.joinedTeams = response.joinedTeams
+                                this.pendingInvitations = response.pendingInvitations
+                        } catch (error) {
+                                console.error('Error fetching teams:', error)
+                        } finally {
+                                this.isLoading = false
+                        }
+                },
 
 		async fetchTeam(teamId) {
 			console.log('Fetching team details for team ID:', teamId)
@@ -221,17 +209,8 @@ export const useTeamStore = defineStore('team', {
 			}
 		},
 
-		getCurrentTeam(teams, user) {
-			if (!teams || !user || !user.current_team_id) return null
-
-			// Find the current team from the list of teams
-			return (
-				teams.ownedTeams.find((team) => team.id === user.current_team_id) || teams.joinedTeams.find((team) => team.id === user.current_team_id) || null
-			)
-		},
-
-		async generatePasswordResetUrl(teamId, userId) {
-			console.log('Generating password reset URL for user ID:', userId)
+                async generatePasswordResetUrl(teamId, userId) {
+                        console.log('Generating password reset URL for user ID:', userId)
 
 			try {
 				const response = await api.post(`/teams/${teamId}/members/${userId}/password-reset`)


### PR DESCRIPTION
## Summary
- Stop relying on user current_team_id when loading team data
- Drive navigation and team polling from the teamId route param
- Derive job status actions and team pages from the route’s teamId

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_68978be4456883238cf00b4d8b8c112d