### PR TITLE
Normalize timezone handling for visibility queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ These mention counts power visibility metrics:
 -   **OrganizationVisibilityController@index** aggregates mentions across all prompts in a campaign and ranks organizations by visibility (mentions ÷ total responses).
 -   **OrganizationVisibilityChartController** and **PromptVisibilityChartController** provide visibility over time using daily, weekly or monthly intervals.
 
+## Timezones
+
+All timestamps are stored in UTC. When filtering by date, controllers accept a `timezone` query parameter and convert the provided `start_date` and `end_date` from that timezone into UTC before querying. Results are converted back to the user's timezone for display, so clients should send their IANA timezone identifier or already-normalized UTC strings.
+
 ## Laravel Models
 
 This section summarises the main Eloquent models and how they relate to each other.

--- a/app/Http/Controllers/OrganizationVisibilityChartController.php
+++ b/app/Http/Controllers/OrganizationVisibilityChartController.php
@@ -20,11 +20,14 @@ class OrganizationVisibilityChartController extends Controller
         $request->validate([
             'start_date' => 'nullable|date',
             'end_date' => 'nullable|date|after_or_equal:start_date',
-            'interval' => 'nullable|in:daily,weekly,monthly'
+            'interval' => 'nullable|in:daily,weekly,monthly',
+            'timezone' => 'nullable|timezone'
         ]);
 
         $teamId = $team->id;
         $campaignId = $campaign->id;
+
+        $timezone = $request->input('timezone', 'UTC');
 
         // Handle "all_time" case - if dates are not provided, get the date range from responses
         if (!$request->start_date || !$request->end_date) {
@@ -45,12 +48,15 @@ class OrganizationVisibilityChartController extends Controller
                 ]);
             }
 
-            $startDate = Carbon::parse($firstResponse->created_at)->startOfDay();
-            $endDate = Carbon::parse($lastResponse->created_at)->endOfDay();
+            $startDateUser = Carbon::parse($firstResponse->created_at)->setTimezone($timezone)->startOfDay();
+            $endDateUser = Carbon::parse($lastResponse->created_at)->setTimezone($timezone)->endOfDay();
         } else {
-            $startDate = Carbon::parse($request->start_date);
-            $endDate = Carbon::parse($request->end_date);
+            $startDateUser = Carbon::parse($request->start_date, $timezone)->startOfDay();
+            $endDateUser = Carbon::parse($request->end_date, $timezone)->endOfDay();
         }
+
+        $startDate = $startDateUser->copy()->setTimezone('UTC');
+        $endDate = $endDateUser->copy()->setTimezone('UTC');
 
         $interval = $request->input('interval', 'daily');
 
@@ -61,7 +67,7 @@ class OrganizationVisibilityChartController extends Controller
             ->get();
 
         // Generate date intervals
-        $intervals = $this->generateIntervals($startDate, $endDate, $interval);
+        $intervals = $this->generateIntervals($startDateUser, $endDateUser, $interval);
 
         $chartData = [];
 
@@ -76,12 +82,14 @@ class OrganizationVisibilityChartController extends Controller
             foreach ($intervals as $intervalData) {
                 $intervalStart = $intervalData['start'];
                 $intervalEnd = $intervalData['end'];
+                $intervalStartUtc = $intervalStart->copy()->setTimezone('UTC');
+                $intervalEndUtc = $intervalEnd->copy()->setTimezone('UTC');
 
                 // Calculate visibility for this interval
                 $totalResponses = Response::whereHas('prompt', function ($query) use ($teamId, $campaignId) {
                     $query->where('team_id', $teamId)->where('campaign_id', $campaignId);
                 })
-                    ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                    ->whereBetween('created_at', [$intervalStartUtc, $intervalEndUtc])
                     ->count();
 
                 $totalMentions = 0;
@@ -92,7 +100,7 @@ class OrganizationVisibilityChartController extends Controller
                         ->whereHas('terms', function ($query) use ($termIds) {
                             $query->whereIn('terms.id', $termIds);
                         })
-                        ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                        ->whereBetween('created_at', [$intervalStartUtc, $intervalEndUtc])
                         ->count();
                 }
 
@@ -120,8 +128,8 @@ class OrganizationVisibilityChartController extends Controller
         return response()->json([
             'organizations' => $chartData,
             'interval' => $interval,
-            'start_date' => $startDate->format('Y-m-d'),
-            'end_date' => $endDate->format('Y-m-d')
+            'start_date' => $startDateUser->format('Y-m-d'),
+            'end_date' => $endDateUser->format('Y-m-d')
         ]);
     }
 

--- a/app/Http/Controllers/OrganizationVisibilityController.php
+++ b/app/Http/Controllers/OrganizationVisibilityController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use App\Models\Team;
 use App\Models\Campaign;
+use Illuminate\Support\Carbon;
 
 class OrganizationVisibilityController extends Controller
 {
@@ -22,14 +23,20 @@ class OrganizationVisibilityController extends Controller
 		$campaignId = $campaign->id;
 
 		// Validate request parameters
-		$request->validate([
-			'start_date' => 'nullable|date',
-			'end_date' => 'nullable|date|after_or_equal:start_date',
-		]);
+                $request->validate([
+                        'start_date' => 'nullable|date',
+                        'end_date' => 'nullable|date|after_or_equal:start_date',
+                        'timezone' => 'nullable|timezone',
+                ]);
 
-		$startDate = $request->input('start_date');
-		$endDate = $request->input('end_date');
-		$endDateTime = null;
+                $timezone = $request->input('timezone', 'UTC');
+
+                $startDateUtc = $request->start_date
+                        ? Carbon::parse($request->start_date, $timezone)->setTimezone('UTC')
+                        : null;
+                $endDateUtc = $request->end_date
+                        ? Carbon::parse($request->end_date, $timezone)->endOfDay()->setTimezone('UTC')
+                        : null;
 
 		// Get total responses count with date filtering
 		$totalResponsesQuery = DB::table('responses')
@@ -37,14 +44,12 @@ class OrganizationVisibilityController extends Controller
 			->where('prompts.team_id', $teamId)
 			->where('prompts.campaign_id', $campaignId);
 
-		if ($startDate) {
-			$totalResponsesQuery->where('responses.created_at', '>=', $startDate);
-		}
-		if ($endDate) {
-			// Extend end date to include entire day (23:59:59)
-			$endDateTime = $endDate . ' 23:59:59';
-			$totalResponsesQuery->where('responses.created_at', '<=', $endDateTime);
-		}
+                if ($startDateUtc) {
+                        $totalResponsesQuery->where('responses.created_at', '>=', $startDateUtc);
+                }
+                if ($endDateUtc) {
+                        $totalResponsesQuery->where('responses.created_at', '<=', $endDateUtc);
+                }
 
 		$totalResponses = $totalResponsesQuery->count();
 
@@ -67,8 +72,8 @@ class OrganizationVisibilityController extends Controller
                AND p.campaign_id = ?
                AND org.team_id = ?
                AND (org.campaign_id = ? OR (org.campaign_id IS NULL AND org.is_competitor = 0))
-               ' . ($startDate ? 'AND r.created_at >= ?' : '') . '
-               ' . ($endDate ? 'AND r.created_at <= ?' : '') . '
+               ' . ($startDateUtc ? 'AND r.created_at >= ?' : '') . '
+               ' . ($endDateUtc ? 'AND r.created_at <= ?' : '') . '
                GROUP BY t.organization_id
            ) as mention_data'), 'organizations.id', '=', 'mention_data.organization_id')
 			->where('organizations.team_id', $teamId)
@@ -78,9 +83,9 @@ class OrganizationVisibilityController extends Controller
 			});
 
 		// Bind parameters for the subquery
-		$bindings = [$teamId, $campaignId, $teamId, $campaignId];
-		if ($startDate) $bindings[] = $startDate;
-		if ($endDate) $bindings[] = $endDateTime;
+                $bindings = [$teamId, $campaignId, $teamId, $campaignId];
+                if ($startDateUtc) $bindings[] = $startDateUtc->toDateTimeString();
+                if ($endDateUtc) $bindings[] = $endDateUtc->toDateTimeString();
 
 		$organizations = $organizationsWithMentions->addBinding($bindings, 'join')->get();
 

--- a/app/Http/Controllers/PromptController.php
+++ b/app/Http/Controllers/PromptController.php
@@ -9,6 +9,7 @@ use App\Models\Organization;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Carbon;
 
 class PromptController extends Controller
 {
@@ -18,16 +19,17 @@ class PromptController extends Controller
         $request->validate([
             'start_date' => 'nullable|date',
             'end_date' => 'nullable|date|after_or_equal:start_date',
+            'timezone' => 'nullable|timezone',
         ]);
 
-        $startDate = $request->input('start_date');
-        $endDate = $request->input('end_date');
-        $endDateTime = null;
+        $timezone = $request->input('timezone', 'UTC');
 
-        if ($endDate) {
-            // Extend end date to include entire day (23:59:59)
-            $endDateTime = $endDate . ' 23:59:59';
-        }
+        $startDateUtc = $request->start_date
+            ? Carbon::parse($request->start_date, $timezone)->setTimezone('UTC')
+            : null;
+        $endDateUtc = $request->end_date
+            ? Carbon::parse($request->end_date, $timezone)->endOfDay()->setTimezone('UTC')
+            : null;
 
         $prompts = Prompt::where('team_id', $team->id)
             ->where('campaign_id', $campaign->id)
@@ -39,12 +41,12 @@ class PromptController extends Controller
                     });
                 },
                 // Count responses with date filtering
-                'responses' => function ($query) use ($startDate, $endDateTime) {
-                    if ($startDate) {
-                        $query->where('created_at', '>=', $startDate);
+                'responses' => function ($query) use ($startDateUtc, $endDateUtc) {
+                    if ($startDateUtc) {
+                        $query->where('created_at', '>=', $startDateUtc);
                     }
-                    if ($endDateTime) {
-                        $query->where('created_at', '<=', $endDateTime);
+                    if ($endDateUtc) {
+                        $query->where('created_at', '<=', $endDateUtc);
                     }
                 }
             ])
@@ -52,7 +54,7 @@ class PromptController extends Controller
             ->get();
 
         // Calculate mentions percentage for each prompt with date filtering
-        $prompts->each(function ($prompt) use ($startDate, $endDateTime, $team) {
+        $prompts->each(function ($prompt) use ($startDateUtc, $endDateUtc, $team) {
             $totalResponses = $prompt->responses_count;
 
             if ($totalResponses === 0) {
@@ -84,11 +86,11 @@ class PromptController extends Controller
                     $query->whereIn('terms.id', $termIds);
                 });
 
-            if ($startDate) {
-                $mentionsQuery->where('created_at', '>=', $startDate);
+            if ($startDateUtc) {
+                $mentionsQuery->where('created_at', '>=', $startDateUtc);
             }
-            if ($endDateTime) {
-                $mentionsQuery->where('created_at', '<=', $endDateTime);
+            if ($endDateUtc) {
+                $mentionsQuery->where('created_at', '<=', $endDateUtc);
             }
 
             $mentions = $mentionsQuery->count();

--- a/app/Http/Controllers/PromptVisibilityChartController.php
+++ b/app/Http/Controllers/PromptVisibilityChartController.php
@@ -18,11 +18,14 @@ class PromptVisibilityChartController extends Controller
         $request->validate([
             'start_date' => 'nullable|date',
             'end_date' => 'nullable|date|after_or_equal:start_date',
-            'interval' => 'nullable|in:daily,weekly,monthly'
+            'interval' => 'nullable|in:daily,weekly,monthly',
+            'timezone' => 'nullable|timezone'
         ]);
 
         $teamId = $prompt->team_id;
         $campaignId = $prompt->campaign_id;
+
+        $timezone = $request->input('timezone', 'UTC');
 
         // Handle date range
         if (!$request->start_date || !$request->end_date) {
@@ -38,12 +41,15 @@ class PromptVisibilityChartController extends Controller
                 ]);
             }
 
-            $startDate = Carbon::parse($firstResponse->created_at)->startOfDay();
-            $endDate = Carbon::parse($lastResponse->created_at)->endOfDay();
+            $startDateUser = Carbon::parse($firstResponse->created_at)->setTimezone($timezone)->startOfDay();
+            $endDateUser = Carbon::parse($lastResponse->created_at)->setTimezone($timezone)->endOfDay();
         } else {
-            $startDate = Carbon::parse($request->start_date);
-            $endDate = Carbon::parse($request->end_date);
+            $startDateUser = Carbon::parse($request->start_date, $timezone)->startOfDay();
+            $endDateUser = Carbon::parse($request->end_date, $timezone)->endOfDay();
         }
+
+        $startDate = $startDateUser->copy()->setTimezone('UTC');
+        $endDate = $endDateUser->copy()->setTimezone('UTC');
 
         $interval = $request->input('interval', 'daily');
 
@@ -54,7 +60,7 @@ class PromptVisibilityChartController extends Controller
             ->get();
 
         // Generate date intervals
-        $intervals = $this->generateIntervals($startDate, $endDate, $interval);
+        $intervals = $this->generateIntervals($startDateUser, $endDateUser, $interval);
 
         $chartData = [];
 
@@ -69,10 +75,12 @@ class PromptVisibilityChartController extends Controller
             foreach ($intervals as $intervalData) {
                 $intervalStart = $intervalData['start'];
                 $intervalEnd = $intervalData['end'];
+                $intervalStartUtc = $intervalStart->copy()->setTimezone('UTC');
+                $intervalEndUtc = $intervalEnd->copy()->setTimezone('UTC');
 
                 // Calculate visibility for this interval FOR THIS SPECIFIC PROMPT
                 $totalResponses = $prompt->responses()
-                    ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                    ->whereBetween('created_at', [$intervalStartUtc, $intervalEndUtc])
                     ->count();
 
                 $totalMentions = 0;
@@ -81,7 +89,7 @@ class PromptVisibilityChartController extends Controller
                         ->whereHas('terms', function ($query) use ($termIds) {
                             $query->whereIn('terms.id', $termIds);
                         })
-                        ->whereBetween('created_at', [$intervalStart, $intervalEnd])
+                        ->whereBetween('created_at', [$intervalStartUtc, $intervalEndUtc])
                         ->count();
                 }
 
@@ -109,8 +117,8 @@ class PromptVisibilityChartController extends Controller
         return response()->json([
             'organizations' => $chartData,
             'interval' => $interval,
-            'start_date' => $startDate->format('Y-m-d'),
-            'end_date' => $endDate->format('Y-m-d')
+            'start_date' => $startDateUser->format('Y-m-d'),
+            'end_date' => $endDateUser->format('Y-m-d')
         ]);
     }
 


### PR DESCRIPTION
## Summary
- parse `start_date`/`end_date` with user-supplied timezone and convert to UTC for filtering
- update Prompt/Organization visibility chart controllers to apply timezone conversions per interval
- document UTC storage and timezone parameter in README

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: GitHub 403 – unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_68af5ee20e548323974ca1ac556544be