### PR TITLE
Harden flex processing jobs

### DIFF
--- a/app/Console/Commands/WatchResponses.php
+++ b/app/Console/Commands/WatchResponses.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Response;
+use App\Jobs\PollOpenAIResponseJob;
+
+class WatchResponses extends Command
+{
+    protected $signature = 'responses:watch';
+
+    protected $description = 'Revive or expire stuck responses';
+
+    public function handle(): void
+    {
+        $threshold = now()->subMinutes(30);
+        Response::whereIn('status', ['queued', 'in_progress', 'stalled'])
+            ->where('updated_at', '<', $threshold)
+            ->chunkById(50, function ($responses) {
+                foreach ($responses as $response) {
+                    if (($response->initial_attempts ?? 0) < 5) {
+                        dispatch(new PollOpenAIResponseJob($response->id));
+                    } else {
+                        $response->update(['status' => 'expired', 'error_code' => 'watchdog_expired']);
+                    }
+                }
+            });
+    }
+}
+

--- a/app/Http/Controllers/PromptController.php
+++ b/app/Http/Controllers/PromptController.php
@@ -108,7 +108,7 @@ class PromptController extends Controller
             return response()->json(['message' => 'Not found'], 404);
         }
 
-        $prompt->load(['terms', 'articles']);
+        $prompt->load(['terms', 'articles', 'responses']);
 
         return response()->json($prompt);
     }

--- a/app/Http/Controllers/PromptResponsesController.php
+++ b/app/Http/Controllers/PromptResponsesController.php
@@ -12,6 +12,7 @@ class PromptResponsesController extends Controller
     {
         // Get all responses for this prompt
         $responses = Response::where('prompt_id', $prompt->id)
+            ->select(['id','provider','model','flex','provider_id','status','content','search','usage','poll_attempts','error_code','processing_error_message','created_at','updated_at'])
             ->latest()
             ->get();
         

--- a/app/Http/Controllers/PromptRunBatchController.php
+++ b/app/Http/Controllers/PromptRunBatchController.php
@@ -19,15 +19,12 @@ class PromptRunBatchController extends Controller
             'providers' => 'nullable|array',
             'providers.*' => 'string|in:openai,anthropic,gemini,xai,deepseek',
             'count' => 'nullable|integer|min:1|max:5',
-            'flex' => 'nullable|boolean',
-            'service_tier' => 'nullable|string|in:flex',
         ]);
 
         $providers = $validated['providers'] ?? ['openai'];
         $count = $validated['count'] ?? 1;
         // Always use Flex pricing for batch runs
-        // $serviceTier = 'flex';
-        $serviceTier = null;
+        $serviceTier = 'flex';
 
         // Get all prompts for this team and campaign
         $prompts = Prompt::where('team_id', $team->id)

--- a/app/Jobs/PollOpenAIResponseJob.php
+++ b/app/Jobs/PollOpenAIResponseJob.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Services\OpenAIPromptService;
 use App\Models\Response as ResponseModel;
+use App\Jobs\ResumeStalledResponseJob;
 
 class PollOpenAIResponseJob implements ShouldQueue
 {
@@ -30,6 +31,10 @@ class PollOpenAIResponseJob implements ShouldQueue
      */
     public $timeout = 5;
 
+    protected int $maxPollAttempts = 25;
+    protected int $maxReissueAttempts = 5;
+    protected int $baseDelay = 15;
+
     /**
      * The response ID (DB primary key) to poll.
      *
@@ -47,49 +52,49 @@ class PollOpenAIResponseJob implements ShouldQueue
         try {
             $response = ResponseModel::with('prompt')->find($this->responseDbId);
             if (!$response) {
-                // Nothing to do
                 return;
             }
 
-            // If already completed, nothing to do
-            if ($response->status === 'completed') {
+            if (in_array($response->status, ['completed', 'failed', 'cancelled', 'processing_failed'])) {
                 return;
             }
+
+            $attempt = $response->poll_attempts;
+            $response->update(['poll_attempts' => $attempt + 1, 'last_polled_at' => now()]);
 
             if (!$response->provider_id) {
-                // No OpenAI response id to poll; treat as failed so we re-run
                 $this->reissueIfFailed($response, $openAI);
                 return;
             }
 
-            $fresh = $openAI->retrieveResponse($response->provider_id);
+            try {
+                $fresh = $openAI->retrieveResponse($response->provider_id);
+            } catch (Throwable $e) {
+                $this->scheduleNext($response, $attempt, $e->getCode() ?: null);
+                Log::warning('PollOpenAIResponseJob retrieve failed', ['response_id' => $response->id, 'error' => $e->getMessage()]);
+                return;
+            }
+
             $status = $fresh->status ?? 'in_progress';
 
             if ($status === 'completed') {
-                // Update with final content and usage, mark completed
-                $response->content = $fresh->content ?? '';
-                $response->usage = $fresh->usage ?? null;
-                $response->status = 'completed';
-                $response->save();
-
-                // Delegate further processing to a dedicated job
+                $response->update([
+                    'content' => $fresh->content ?? '',
+                    'usage' => $fresh->usage ?? null,
+                    'status' => 'completed',
+                ]);
                 dispatch(new ProcessCompletedResponseJob($response->id));
+                Log::info('PollOpenAIResponseJob completed', ['response_id' => $response->id]);
                 return;
             }
 
-            if ($status === 'failed') {
-                // Try again per requirements
+            if (in_array($status, ['failed', 'cancelled', 'incomplete'])) {
                 $this->reissueIfFailed($response, $openAI);
                 return;
             }
 
-            // Still in progress; schedule another poll in 15 seconds
-            $response->status = $status;
-            $response->save();
-
-            $next = new self($response->id);
-            $next->delay(now()->addSeconds(15));
-            dispatch($next);
+            $response->update(['status' => $status]);
+            $this->scheduleNext($response, $attempt);
         } catch (Throwable $exception) {
             Log::error('PollOpenAIResponseJob failed with exception', [
                 'response_db_id' => $this->responseDbId,
@@ -99,34 +104,55 @@ class PollOpenAIResponseJob implements ShouldQueue
         }
     }
 
+    protected function scheduleNext(ResponseModel $response, int $attempt, ?string $errorCode = null): void
+    {
+        if ($attempt + 1 >= $this->maxPollAttempts) {
+            $response->update(['status' => 'stalled', 'error_code' => $errorCode]);
+            dispatch((new ResumeStalledResponseJob($response->id))->delay(now()->addHour()));
+            return;
+        }
+        $delay = (int) min($this->baseDelay * (2 ** $attempt), 900);
+        $delay = (int) ($delay * random_int(80, 120) / 100);
+        $response->update(['next_poll_at' => now()->addSeconds($delay), 'error_code' => $errorCode]);
+        $this->release($delay);
+    }
+
     protected function reissueIfFailed(ResponseModel $response, OpenAIPromptService $openAI): void
     {
+        $attempts = $response->initial_attempts ?? 0;
+        if ($attempts >= $this->maxReissueAttempts) {
+            $response->update(['status' => 'failed']);
+            Log::error('Response failed after max retries', ['response_id' => $response->id]);
+            return;
+        }
+
         try {
             $prompt = $response->prompt;
             $options = [];
             if ($response->flex) {
                 $options['service_tier'] = 'flex';
             }
-            // Use the model stored on the response
             $fresh = $openAI->getResponse($prompt->content, $response->model, $options);
-
-            // Update response with new id/status and clear content until completion
-            $response->provider_id = $fresh->id ?? null;
-            $response->status = $fresh->status ?? 'in_progress';
-            $response->content = '';
-            $response->usage = null;
-            $response->save();
-
-            // Schedule the next poll
-            $next = new self($response->id);
-            $next->delay(now()->addSeconds(15));
-            dispatch($next);
+            $response->update([
+                'provider_id' => $fresh->id ?? null,
+                'status' => $fresh->status ?? 'in_progress',
+                'content' => '',
+                'usage' => null,
+                'initial_attempts' => $attempts + 1,
+                'poll_attempts' => 0,
+            ]);
+            $this->release($this->baseDelay);
         } catch (\Exception $e) {
+            $response->update(['status' => 'failed', 'error_code' => $e->getCode() ?: null]);
             Log::error('Failed to reissue OpenAI response after failure', [
                 'response_id' => $response->id,
                 'error' => $e->getMessage(),
             ]);
-            throw $e;
         }
+    }
+
+    public function tags(): array
+    {
+        return ['response:' . $this->responseDbId];
     }
 }

--- a/app/Jobs/ProcessCompletedResponseJob.php
+++ b/app/Jobs/ProcessCompletedResponseJob.php
@@ -32,12 +32,10 @@ class ProcessCompletedResponseJob implements ShouldQueue
     public function handle(OpenAIPromptService $openAI): void
     {
         $response = ResponseModel::with('prompt')->find($this->responseDbId);
-        if (!$response) return;
+        if (!$response || $response->status !== 'completed') {
+            return;
+        }
 
-        // Only process completed responses
-        if ($response->status !== 'completed') return;
-
-        // Attempt to enrich with search annotations if provider_id exists
         try {
             if ($response->provider_id) {
                 $fresh = $openAI->retrieveResponse($response->provider_id);
@@ -50,20 +48,28 @@ class ProcessCompletedResponseJob implements ShouldQueue
             ]);
         }
 
-        // Scan for terms and update pivot/relations
-        $this->checkForTerms($response, $response->prompt);
-
-        // If this is the first COMPLETED response for the prompt, run competitor finder
         try {
+            $this->checkForTerms($response, $response->prompt);
+
             if ($response->prompt->responses()->where('status', 'completed')->count() == 1) {
                 dispatch(new FindCompetitorsInResponseJob($response->prompt));
             }
-        } catch (\Exception $e) {
-            Log::error('Failed to dispatch FindCompetitorsInResponseJob (process)', [
-                'prompt_id' => $response->prompt->id,
+        } catch (Throwable $e) {
+            $response->update([
+                'status' => 'processing_failed',
+                'processing_error_code' => $e->getCode() ?: null,
+                'processing_error_message' => $e->getMessage(),
+            ]);
+            Log::error('ProcessCompletedResponseJob failed', [
+                'response_id' => $response->id,
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    public function tags(): array
+    {
+        return ['response:' . $this->responseDbId];
     }
 
     protected function saveSearchData(object $llmResponse, ResponseModel $response): void

--- a/app/Jobs/ResumeStalledResponseJob.php
+++ b/app/Jobs/ResumeStalledResponseJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Response;
+use Illuminate\Support\Facades\Log;
+
+class ResumeStalledResponseJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $timeout = 5;
+
+    protected int $responseId;
+    protected int $baseDelay = 15;
+
+    public function __construct(int $responseId)
+    {
+        $this->responseId = $responseId;
+    }
+
+    public function handle(): void
+    {
+        $response = Response::find($this->responseId);
+        if (!$response || $response->status !== 'stalled') {
+            return;
+        }
+
+        $response->update(['poll_attempts' => 0, 'status' => 'queued']);
+        dispatch((new PollOpenAIResponseJob($response->id))->delay($this->baseDelay));
+        Log::info('ResumeStalledResponseJob dispatched PollOpenAIResponseJob', ['response_id' => $response->id, 'job_id' => $this->job->getJobId() ?? 'unknown']);
+    }
+
+    public function tags(): array
+    {
+        return ['response:' . $this->responseId];
+    }
+}
+

--- a/app/Jobs/RunPromptJob.php
+++ b/app/Jobs/RunPromptJob.php
@@ -78,6 +78,8 @@ class RunPromptJob implements ShouldQueue
      * @param  array  $providers
      * @param  int  $teamId
      * @param  int  $campaignId
+     * @param  string|null $serviceTier Optional OpenAI service tier (e.g., 'flex')
+     * @param  int|null $responseId Existing response id when resuming
      * @return void
      */
     public function __construct(Prompt $prompt, array $providers, int $teamId, int $campaignId, ?string $serviceTier = null, ?int $responseId = null)
@@ -103,7 +105,7 @@ class RunPromptJob implements ShouldQueue
             }
 
             $providerName = 'openai';
-            $model = 'gpt-4';
+            $model = 'gpt-5';
 
             if (!$this->responseId) {
                 $response = $this->prompt->responses()->create([

--- a/app/Jobs/RunPromptJob.php
+++ b/app/Jobs/RunPromptJob.php
@@ -105,7 +105,7 @@ class RunPromptJob implements ShouldQueue
             }
 
             $providerName = 'openai';
-            $model = 'gpt-5';
+            $model = $openAI->defaultModel();
 
             if (!$this->responseId) {
                 $response = $this->prompt->responses()->create([
@@ -131,7 +131,7 @@ class RunPromptJob implements ShouldQueue
             }
 
             try {
-                $llm = $openAI->getResponse($this->prompt->content, $model, $options);
+                $llm = $openAI->getResponse($this->prompt->content, null, $options);
             } catch (Throwable $e) {
                 $attempt++;
                 $delay = (int) min($this->baseDelay * (2 ** ($attempt - 1)), 900);

--- a/app/Jobs/RunPromptJob.php
+++ b/app/Jobs/RunPromptJob.php
@@ -60,6 +60,18 @@ class RunPromptJob implements ShouldQueue
     protected $campaignId;
 
     /**
+     * The response DB id once created.
+     */
+    protected ?int $responseId = null;
+
+    /**
+     * Max attempts when creating the OpenAI response.
+     */
+    protected int $maxInitialAttempts = 5;
+
+    protected int $baseDelay = 15; // seconds
+
+    /**
      * Create a new job instance.
      *
      * @param  \App\Models\Prompt  $prompt
@@ -68,12 +80,13 @@ class RunPromptJob implements ShouldQueue
      * @param  int  $campaignId
      * @return void
      */
-    public function __construct(Prompt $prompt, array $providers = [], int $teamId, int $campaignId, ?string $serviceTier = null)
+    public function __construct(Prompt $prompt, array $providers, int $teamId, int $campaignId, ?string $serviceTier = null, ?int $responseId = null)
     {
         $this->teamId = $teamId;
         $this->campaignId = $campaignId;
         $this->prompt = $prompt;
         $this->serviceTier = $serviceTier;
+        $this->responseId = $responseId;
     }
 
     /**
@@ -89,32 +102,62 @@ class RunPromptJob implements ShouldQueue
                 return;
             }
 
-            // Simplified: always use OpenAI gpt-4
             $providerName = 'openai';
             $model = 'gpt-4';
 
-            // Get response from the LLM (single provider for reliability)
+            if (!$this->responseId) {
+                $response = $this->prompt->responses()->create([
+                    'provider' => $providerName,
+                    'model' => $model,
+                    'flex' => $this->serviceTier === 'flex',
+                    'status' => 'queued',
+                    'content' => '',
+                ]);
+                $this->responseId = $response->id;
+            } else {
+                $response = \App\Models\Response::find($this->responseId);
+            }
+
+            if (!$response) {
+                return;
+            }
+
+            $attempt = $response->initial_attempts ?? 0;
             $options = [];
             if ($this->serviceTier === 'flex') {
                 $options['service_tier'] = 'flex';
             }
-            $llm = $openAI->getResponse($this->prompt->content, $model, $options);
 
-            // Always create a placeholder and rely on polling to finalize
-            $response = $this->prompt->responses()->create([
-                'provider' => $providerName,
-                'model' => $model,
-                'flex' => $this->serviceTier === 'flex',
-                'status' => 'in_progress',
+            try {
+                $llm = $openAI->getResponse($this->prompt->content, $model, $options);
+            } catch (Throwable $e) {
+                $attempt++;
+                $delay = (int) min($this->baseDelay * (2 ** ($attempt - 1)), 900);
+                $delay = (int) ($delay * random_int(80, 120) / 100);
+                $response->update([
+                    'initial_attempts' => $attempt,
+                    'status' => 'queued',
+                    'error_code' => $e->getCode() ?: null,
+                ]);
+                if ($attempt >= $this->maxInitialAttempts) {
+                    $response->update(['status' => 'failed']);
+                    Log::error('RunPromptJob exceeded attempts', ['response_id' => $response->id]);
+                    return;
+                }
+                $this->release($delay);
+                return;
+            }
+
+            $response->update([
+                'status' => $llm->status ?? 'in_progress',
                 'provider_id' => $llm->id ?? null,
-                'content' => '',
-                'usage' => null,
+                'usage' => $llm->usage ?? null,
             ]);
 
-            // Schedule a poll after 15 seconds to reduce costs
             $pollJob = new PollOpenAIResponseJob($response->id);
             $pollJob->delay(now()->addSeconds(15));
             dispatch($pollJob);
+            Log::info('RunPromptJob dispatched PollOpenAIResponseJob', ['response_id' => $response->id, 'job_id' => $this->job->getJobId() ?? 'unknown']);
         } catch (Throwable $exception) {
             Log::error('RunPromptJob failed with exception', [
                 'prompt_id' => $this->prompt->id,
@@ -124,6 +167,11 @@ class RunPromptJob implements ShouldQueue
             ]);
             throw $exception;
         }
+    }
+
+    public function tags(): array
+    {
+        return ['prompt:' . $this->prompt->id];
     }
 
     /**

--- a/app/Models/Response.php
+++ b/app/Models/Response.php
@@ -22,12 +22,21 @@ class Response extends Model
         'content',
         'search',
         'usage',
+        'initial_attempts',
+        'poll_attempts',
+        'last_polled_at',
+        'next_poll_at',
+        'error_code',
+        'processing_error_code',
+        'processing_error_message',
     ];
 
     protected $casts = [
         'search' => 'array',
         'usage' => 'array',
         'flex' => 'boolean',
+        'last_polled_at' => 'datetime',
+        'next_poll_at' => 'datetime',
     ];
 
     /**

--- a/app/Services/OpenAIPromptService.php
+++ b/app/Services/OpenAIPromptService.php
@@ -19,13 +19,13 @@ class OpenAIPromptService
      *
      * @param string $promptContent The prompt to send
      * @param string|null $model Optional override model
+     * @param array $options Additional request options (e.g., service_tier)
      * @return object Object with content, annotations and usage
      */
     public function getResponse(string $promptContent, ?string $model = null, array $options = []): object
     {
         $startTime = microtime(true);
-        // Enforce gpt-4o for prompt runs regardless of caller input
-        $modelToUse = 'gpt-4o';
+        $modelToUse = $model ?? $this->defaultModel();
 
         try {
             $request = [
@@ -59,10 +59,9 @@ class OpenAIPromptService
         }
     }
 
-    protected function defaultModel(): string
+    public function defaultModel(): string
     {
-        // Kept for future configurability; currently unused since we enforce gpt-4o
-        return 'gpt-4o';
+        return 'gpt-5';
     }
 
     /**
@@ -124,13 +123,13 @@ class OpenAIPromptService
             $response = OpenAI::responses()->retrieve($responseId);
             return $this->parseResponse($response);
         } catch (\OpenAI\Exceptions\ErrorException $e) {
-            $this->logError('OpenAI API ErrorException (retrieve)', $e, 'N/A', 'gpt-4o', $startTime);
+            $this->logError('OpenAI API ErrorException (retrieve)', $e, 'N/A', $this->defaultModel(), $startTime);
             throw $e;
         } catch (\GuzzleHttp\Exception\RequestException $e) {
-            $this->logError('OpenAI HTTP RequestException (retrieve)', $e, 'N/A', 'gpt-4o', $startTime, true);
+            $this->logError('OpenAI HTTP RequestException (retrieve)', $e, 'N/A', $this->defaultModel(), $startTime, true);
             throw $e;
         } catch (\Exception $e) {
-            $this->logError('OpenAI Prompt Service: Unexpected error (retrieve)', $e, 'N/A', 'gpt-4o', $startTime);
+            $this->logError('OpenAI Prompt Service: Unexpected error (retrieve)', $e, 'N/A', $this->defaultModel(), $startTime);
             throw $e;
         }
     }

--- a/database/migrations/2025_09_20_000000_add_retry_tracking_to_responses_table.php
+++ b/database/migrations/2025_09_20_000000_add_retry_tracking_to_responses_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->unsignedInteger('initial_attempts')->default(0)->after('usage');
+            $table->unsignedInteger('poll_attempts')->default(0)->after('initial_attempts');
+            $table->timestamp('last_polled_at')->nullable()->after('poll_attempts');
+            $table->timestamp('next_poll_at')->nullable()->after('last_polled_at');
+            $table->string('error_code')->nullable()->after('next_poll_at');
+            $table->string('processing_error_code')->nullable()->after('error_code');
+            $table->text('processing_error_message')->nullable()->after('processing_error_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->dropColumn([
+                'initial_attempts',
+                'poll_attempts',
+                'last_polled_at',
+                'next_poll_at',
+                'error_code',
+                'processing_error_code',
+                'processing_error_message',
+            ]);
+        });
+    }
+};
+

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Foundation\Inspiring;
 
 Schedule::command('model:prune')->daily();
+Schedule::command('responses:watch')->hourly();
 
 Artisan::command('inspire', function () {
 	$this->comment(Inspiring::quote());


### PR DESCRIPTION
## Summary
- add exponential backoff and attempt tracking to RunPromptJob
- implement adaptive polling and reissue logic with ResumeStalledResponseJob
- record processing errors and expose response status/attempt data via API
- add WatchResponses console command scheduled hourly

## Testing
- `composer install` *(fails: require GitHub token)*
- `php artisan test --env=ci` *(fails: missing vendor autoload)*
- `php -l app/Jobs/RunPromptJob.php app/Jobs/PollOpenAIResponseJob.php app/Jobs/ProcessCompletedResponseJob.php app/Jobs/ResumeStalledResponseJob.php app/Models/Response.php app/Console/Commands/WatchResponses.php app/Http/Controllers/PromptController.php app/Http/Controllers/PromptResponsesController.php routes/console.php database/migrations/2025_09_20_000000_add_retry_tracking_to_responses_table.php`


------
https://chatgpt.com/codex/tasks/task_b_68bb47474bb48323bfc15d9e9324833b