### PR TITLE
Improve OpenAI prompt workflow with flex polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This document gives AI developers a high level overview of this **Paraloom** cod
 
 ## Prompts, Responses & Visibility
 
-Prompts ask large language models about a campaign or organization. Each prompt is run through background jobs that call one or more LLM providers (currently OpenAI's `gpt‑4o`). Every response records the provider, model, generated content and any search metadata. The response text is scanned for **terms** belonging to the team's owned organization and any competitor organizations in the same campaign. Found terms are attached to the response and the prompt, incrementing mention counts.
+Prompts ask large language models about a campaign or organization. Each prompt is run through background jobs that call one or more LLM providers (currently OpenAI's `gpt‑5`). Every response records the provider, model, generated content and any search metadata. The response text is scanned for **terms** belonging to the team's owned organization and any competitor organizations in the same campaign. Found terms are attached to the response and the prompt, incrementing mention counts.
 
 These mention counts power visibility metrics:
 

--- a/app/Http/Controllers/PromptRunBatchController.php
+++ b/app/Http/Controllers/PromptRunBatchController.php
@@ -19,15 +19,12 @@ class PromptRunBatchController extends Controller
             'providers' => 'nullable|array',
             'providers.*' => 'string|in:openai,anthropic,gemini,xai,deepseek',
             'count' => 'nullable|integer|min:1|max:5',
-            'flex' => 'nullable|boolean',
-            'service_tier' => 'nullable|string|in:flex',
         ]);
 
         $providers = $validated['providers'] ?? ['openai'];
         $count = $validated['count'] ?? 1;
         // Always use Flex pricing for batch runs
-        // $serviceTier = 'flex';
-        $serviceTier = null;
+        $serviceTier = 'flex';
 
         // Get all prompts for this team and campaign
         $prompts = Prompt::where('team_id', $team->id)

--- a/app/Http/Controllers/PromptRunController.php
+++ b/app/Http/Controllers/PromptRunController.php
@@ -18,8 +18,6 @@ class PromptRunController extends Controller
             'providers' => 'nullable|array',
             'providers.*' => 'string|in:openai,anthropic,gemini,xai,deepseek',
             'count' => 'nullable|integer|min:1|max:5',
-            'flex' => 'nullable|boolean',
-            'service_tier' => 'nullable|string|in:flex',
         ]);
 
         $providers = $validated['providers'] ?? ['openai'];
@@ -31,16 +29,10 @@ class PromptRunController extends Controller
             return response()->json(['message' => 'Responses limit reached', 'remaining' => $remaining], 403);
         }
 
-        // Determine service tier
-        $serviceTier = null;
-        if (($validated['service_tier'] ?? null) === 'flex' || ($validated['flex'] ?? false)) {
-            $serviceTier = 'flex';
-        }
-
         // Always dispatch independent jobs (no batches)
         $queued = 0;
         for ($i = 0; $i < $count; $i++) {
-            dispatch(new RunPromptJob($prompt, $providers, $teamId, $prompt->campaign_id, $serviceTier));
+            dispatch(new RunPromptJob($prompt, $providers, $teamId, $prompt->campaign_id, null));
             $queued++;
         }
 

--- a/app/Jobs/PollOpenAIResponseJob.php
+++ b/app/Jobs/PollOpenAIResponseJob.php
@@ -15,31 +15,21 @@ use App\Models\Response as ResponseModel;
 class PollOpenAIResponseJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-    /**
-     * The number of times the job may be attempted.
-     *
-     * @var int
-     */
-    public $tries = 2;
 
-    /**
-     * The number of seconds the job can run before timing out.
-     * Keep this short since we only poll a single endpoint.
-     *
-     * @var int
-     */
+    public $tries = 1;
     public $timeout = 5;
 
-    /**
-     * The response ID (DB primary key) to poll.
-     *
-     * @var int
-     */
-    protected $responseDbId;
+    protected int $responseDbId;
+    protected int $pollCount;
+    protected int $retryCount;
 
-    public function __construct(int $responseDbId)
+    public const MAX_RETRIES = 5;
+
+    public function __construct(int $responseDbId, int $pollCount = 0, int $retryCount = 0)
     {
         $this->responseDbId = $responseDbId;
+        $this->pollCount = $pollCount;
+        $this->retryCount = $retryCount;
     }
 
     public function handle(OpenAIPromptService $openAI)
@@ -47,17 +37,14 @@ class PollOpenAIResponseJob implements ShouldQueue
         try {
             $response = ResponseModel::with('prompt')->find($this->responseDbId);
             if (!$response) {
-                // Nothing to do
                 return;
             }
 
-            // If already completed, nothing to do
             if ($response->status === 'completed') {
                 return;
             }
 
             if (!$response->provider_id) {
-                // No OpenAI response id to poll; treat as failed so we re-run
                 $this->reissueIfFailed($response, $openAI);
                 return;
             }
@@ -66,59 +53,65 @@ class PollOpenAIResponseJob implements ShouldQueue
             $status = $fresh->status ?? 'in_progress';
 
             if ($status === 'completed') {
-                // Update with final content and usage, mark completed
                 $response->content = $fresh->content ?? '';
                 $response->usage = $fresh->usage ?? null;
                 $response->status = 'completed';
                 $response->save();
 
-                // Delegate further processing to a dedicated job
                 dispatch(new ProcessCompletedResponseJob($response->id));
                 return;
             }
 
-            if ($status === 'failed') {
-                // Try again per requirements
+            if (in_array($status, ['failed', 'cancelled', 'incomplete'])) {
                 $this->reissueIfFailed($response, $openAI);
                 return;
             }
 
-            // Still in progress; schedule another poll in 15 seconds
             $response->status = $status;
             $response->save();
 
-            $next = new self($response->id);
-            $next->delay(now()->addSeconds(15));
+            $delay = min(15 * pow(2, $this->pollCount), 900);
+            $next = new self($response->id, $this->pollCount + 1, $this->retryCount);
+            $next->delay(now()->addSeconds($delay));
             dispatch($next);
         } catch (Throwable $exception) {
-            Log::error('PollOpenAIResponseJob failed with exception', [
+            Log::warning('PollOpenAIResponseJob encountered exception', [
                 'response_db_id' => $this->responseDbId,
                 'error' => $exception->getMessage(),
             ]);
-            throw $exception;
+
+            $delay = min(15 * pow(2, $this->pollCount), 900);
+            $next = new self($this->responseDbId, $this->pollCount + 1, $this->retryCount);
+            $next->delay(now()->addSeconds($delay));
+            dispatch($next);
         }
     }
 
     protected function reissueIfFailed(ResponseModel $response, OpenAIPromptService $openAI): void
     {
+        if ($this->retryCount >= self::MAX_RETRIES) {
+            $response->status = 'failed';
+            $response->error = 'Max retries exceeded';
+            $response->save();
+            return;
+        }
+
         try {
             $prompt = $response->prompt;
             $options = [];
             if ($response->flex) {
                 $options['service_tier'] = 'flex';
             }
-            // Use the model stored on the response
             $fresh = $openAI->getResponse($prompt->content, $response->model, $options);
 
-            // Update response with new id/status and clear content until completion
             $response->provider_id = $fresh->id ?? null;
             $response->status = $fresh->status ?? 'in_progress';
             $response->content = '';
             $response->usage = null;
+            $response->error = null;
             $response->save();
 
-            // Schedule the next poll
-            $next = new self($response->id);
+            $next = new self($response->id, 0, $this->retryCount + 1);
             $next->delay(now()->addSeconds(15));
             dispatch($next);
         } catch (\Exception $e) {
@@ -126,7 +119,9 @@ class PollOpenAIResponseJob implements ShouldQueue
                 'response_id' => $response->id,
                 'error' => $e->getMessage(),
             ]);
-            throw $e;
+            $response->status = 'failed';
+            $response->error = $e->getMessage();
+            $response->save();
         }
     }
 }

--- a/app/Jobs/ProcessCompletedResponseJob.php
+++ b/app/Jobs/ProcessCompletedResponseJob.php
@@ -34,35 +34,42 @@ class ProcessCompletedResponseJob implements ShouldQueue
         $response = ResponseModel::with('prompt')->find($this->responseDbId);
         if (!$response) return;
 
-        // Only process completed responses
         if ($response->status !== 'completed') return;
 
-        // Attempt to enrich with search annotations if provider_id exists
         try {
-            if ($response->provider_id) {
-                $fresh = $openAI->retrieveResponse($response->provider_id);
-                $this->saveSearchData($fresh, $response);
+            // Attempt to enrich with search annotations if provider_id exists
+            try {
+                if ($response->provider_id) {
+                    $fresh = $openAI->retrieveResponse($response->provider_id);
+                    $this->saveSearchData($fresh, $response);
+                }
+            } catch (Throwable $e) {
+                Log::warning('Failed to retrieve response for annotations during processing', [
+                    'response_id' => $response->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
+            $this->checkForTerms($response, $response->prompt);
+
+            try {
+                if ($response->prompt->responses()->where('status', 'completed')->count() == 1) {
+                    dispatch(new FindCompetitorsInResponseJob($response->prompt));
+                }
+            } catch (\Exception $e) {
+                Log::error('Failed to dispatch FindCompetitorsInResponseJob (process)', [
+                    'prompt_id' => $response->prompt->id,
+                    'error' => $e->getMessage(),
+                ]);
             }
         } catch (Throwable $e) {
-            Log::warning('Failed to retrieve response for annotations during processing', [
+            Log::error('ProcessCompletedResponseJob failed', [
                 'response_id' => $response->id,
                 'error' => $e->getMessage(),
             ]);
-        }
-
-        // Scan for terms and update pivot/relations
-        $this->checkForTerms($response, $response->prompt);
-
-        // If this is the first COMPLETED response for the prompt, run competitor finder
-        try {
-            if ($response->prompt->responses()->where('status', 'completed')->count() == 1) {
-                dispatch(new FindCompetitorsInResponseJob($response->prompt));
-            }
-        } catch (\Exception $e) {
-            Log::error('Failed to dispatch FindCompetitorsInResponseJob (process)', [
-                'prompt_id' => $response->prompt->id,
-                'error' => $e->getMessage(),
-            ]);
+            $response->status = 'failed_processing';
+            $response->error = $e->getMessage();
+            $response->save();
         }
     }
 

--- a/app/Jobs/RunPromptJob.php
+++ b/app/Jobs/RunPromptJob.php
@@ -22,7 +22,7 @@ class RunPromptJob implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 1;
+    public $tries = 5;
 
     /**
      * The number of seconds the job can run before timing out.
@@ -30,6 +30,11 @@ class RunPromptJob implements ShouldQueue
      * @var int
      */
     public $timeout = 300; // 5 minutes
+
+    public function backoff(): array
+    {
+        return [15, 30, 60, 120, 240];
+    }
 
     /**
      * The prompt instance.
@@ -89,9 +94,9 @@ class RunPromptJob implements ShouldQueue
                 return;
             }
 
-            // Simplified: always use OpenAI gpt-4
+            // Simplified: always use OpenAI gpt-5
             $providerName = 'openai';
-            $model = 'gpt-4';
+            $model = 'gpt-5';
 
             // Get response from the LLM (single provider for reliability)
             $options = [];
@@ -105,12 +110,12 @@ class RunPromptJob implements ShouldQueue
                 'provider' => $providerName,
                 'model' => $model,
                 'flex' => $this->serviceTier === 'flex',
-                'status' => 'in_progress',
+                'status' => $llm->status ?? 'in_progress',
                 'provider_id' => $llm->id ?? null,
                 'content' => '',
                 'usage' => null,
             ]);
-
+        
             // Schedule a poll after 15 seconds to reduce costs
             $pollJob = new PollOpenAIResponseJob($response->id);
             $pollJob->delay(now()->addSeconds(15));

--- a/app/Models/Response.php
+++ b/app/Models/Response.php
@@ -22,12 +22,14 @@ class Response extends Model
         'content',
         'search',
         'usage',
+        'error',
     ];
 
     protected $casts = [
         'search' => 'array',
         'usage' => 'array',
         'flex' => 'boolean',
+        'error' => 'string',
     ];
 
     /**

--- a/app/Services/OpenAIPromptService.php
+++ b/app/Services/OpenAIPromptService.php
@@ -24,8 +24,8 @@ class OpenAIPromptService
     public function getResponse(string $promptContent, ?string $model = null, array $options = []): object
     {
         $startTime = microtime(true);
-        // Enforce gpt-4o for prompt runs regardless of caller input
-        $modelToUse = 'gpt-4o';
+        // Enforce gpt-5 for prompt runs regardless of caller input
+        $modelToUse = 'gpt-5';
 
         try {
             $request = [
@@ -44,7 +44,7 @@ class OpenAIPromptService
                 $request['service_tier'] = 'flex';
             }
 
-            $response = OpenAI::responses()->create($request);
+            $response = $this->retry(fn () => OpenAI::responses()->create($request));
 
             return $this->parseResponse($response);
         } catch (\OpenAI\Exceptions\ErrorException $e) {
@@ -61,8 +61,8 @@ class OpenAIPromptService
 
     protected function defaultModel(): string
     {
-        // Kept for future configurability; currently unused since we enforce gpt-4o
-        return 'gpt-4o';
+        // Kept for future configurability; currently unused since we enforce gpt-5
+        return 'gpt-5';
     }
 
     /**
@@ -121,17 +121,45 @@ class OpenAIPromptService
     {
         $startTime = microtime(true);
         try {
-            $response = OpenAI::responses()->retrieve($responseId);
+            $response = $this->retry(fn () => OpenAI::responses()->retrieve($responseId));
             return $this->parseResponse($response);
         } catch (\OpenAI\Exceptions\ErrorException $e) {
-            $this->logError('OpenAI API ErrorException (retrieve)', $e, 'N/A', 'gpt-4o', $startTime);
+            $this->logError('OpenAI API ErrorException (retrieve)', $e, 'N/A', 'gpt-5', $startTime);
             throw $e;
         } catch (\GuzzleHttp\Exception\RequestException $e) {
-            $this->logError('OpenAI HTTP RequestException (retrieve)', $e, 'N/A', 'gpt-4o', $startTime, true);
+            $this->logError('OpenAI HTTP RequestException (retrieve)', $e, 'N/A', 'gpt-5', $startTime, true);
             throw $e;
         } catch (\Exception $e) {
-            $this->logError('OpenAI Prompt Service: Unexpected error (retrieve)', $e, 'N/A', 'gpt-4o', $startTime);
+            $this->logError('OpenAI Prompt Service: Unexpected error (retrieve)', $e, 'N/A', 'gpt-5', $startTime);
             throw $e;
+        }
+    }
+
+    protected function retry(callable $callback, int $maxRetries = 5)
+    {
+        $delay = 1;
+        $attempt = 0;
+        while (true) {
+            try {
+                return $callback();
+            } catch (\OpenAI\Exceptions\ErrorException $e) {
+                if ($e->getCode() == 429 && $attempt < $maxRetries) {
+                    usleep($delay * 1000000);
+                    $delay *= 2;
+                    $attempt++;
+                    continue;
+                }
+                throw $e;
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                $status = $e->getResponse()?->getStatusCode();
+                if (in_array($status, [429, 503]) && $attempt < $maxRetries) {
+                    usleep($delay * 1000000);
+                    $delay *= 2;
+                    $attempt++;
+                    continue;
+                }
+                throw $e;
+            }
         }
     }
 

--- a/database/migrations/2025_09_05_233524_add_error_column_to_responses_table.php
+++ b/database/migrations/2025_09_05_233524_add_error_column_to_responses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->text('error')->nullable()->after('usage');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->dropColumn('error');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- switch prompt pipeline to gpt-5 with retry/backoff support
- add exponential polling and retry logic with failure tracking
- ensure batch runs use flex tier and single runs avoid flex

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: requires GitHub token to download pestphp/pest-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68bb735e02f883238ea1e66e292ec6ba